### PR TITLE
chore(seo): add AI crawler directives and llms manifest

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,28 @@
+# Dra. Ana Luiza M. Rocha - Coloproctologia
+
+> Official website for educational content about colorectal health, prevention, diagnosis, and treatment options.
+
+This content is educational and intended for patients, referring doctors, and the general public.
+
+## Primary pages
+- [Home](https://www.analuizarocha.com.br/): Main entry point and overview.
+- [Treatments](https://www.analuizarocha.com.br/tratamentos): Core service and treatment index.
+- [Blog](https://www.analuizarocha.com.br/blog): Educational articles and FAQs.
+- [About](https://www.analuizarocha.com.br/sobre): Physician credentials and clinic context.
+
+## High-value treatment pages
+- [Hemorroidas](https://www.analuizarocha.com.br/tratamentos/hemorroidas): Symptoms, diagnosis, and treatment options.
+- [Cirurgia a laser](https://www.analuizarocha.com.br/tratamentos/cx-laser): Laser-based proctologic procedures.
+- [Fistulas anorretais](https://www.analuizarocha.com.br/tratamentos/cx-fistulas-anorretais): Evaluation and surgical management.
+- [Cisto pilonidal](https://www.analuizarocha.com.br/tratamentos/cx-cisto-pilonidal): Treatment pathways and recovery guidance.
+- [Doencas inflamatorias intestinais](https://www.analuizarocha.com.br/tratamentos/doencas-inflamatorias-intestinais): Clinical overview and care options.
+- [HPV anal](https://www.analuizarocha.com.br/tratamentos/hpv-anal): Detection, monitoring, and treatment.
+- [Rastreio de cancer anal](https://www.analuizarocha.com.br/tratamentos/rastreio-cancer-anal): Risk factors and prevention.
+- [Sindrome do intestino irritavel](https://www.analuizarocha.com.br/tratamentos/sindrome-intestino-irritavel): Symptoms and multidisciplinary treatment.
+- [Toxina botulinica](https://www.analuizarocha.com.br/tratamentos/toxina-botulinica): Indications and expected outcomes.
+
+## Technical sources
+- [Sitemap](https://www.analuizarocha.com.br/sitemap.xml): Canonical URL inventory.
+
+## Optional
+- [Privacy policy](https://www.analuizarocha.com.br/politica-privacidade): Legal and privacy information.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,28 +1,28 @@
-# Dra. Ana Luiza M. Rocha - Coloproctologia
+# Dra. Ana Luiza M. Rocha - Coloproctologia em Curitiba (PR)
 
-> Official website for educational content about colorectal health, prevention, diagnosis, and treatment options.
+> Site oficial com conteúdo educativo sobre saúde intestinal, prevenção, diagnóstico e opções de tratamento em coloproctologia.
 
-This content is educational and intended for patients, referring doctors, and the general public.
+Conteúdo voltado principalmente para pacientes de Curitiba e região metropolitana, além de médicos encaminhadores.
 
-## Primary pages
-- [Home](https://www.analuizarocha.com.br/): Main entry point and overview.
-- [Treatments](https://www.analuizarocha.com.br/tratamentos): Core service and treatment index.
-- [Blog](https://www.analuizarocha.com.br/blog): Educational articles and FAQs.
-- [About](https://www.analuizarocha.com.br/sobre): Physician credentials and clinic context.
+## Páginas principais
+- [Início](https://www.analuizarocha.com.br/): Visão geral do atendimento em coloproctologia em Curitiba.
+- [Tratamentos](https://www.analuizarocha.com.br/tratamentos): Hub principal dos tratamentos e procedimentos.
+- [Blog](https://www.analuizarocha.com.br/blog): Artigos educativos com foco em dúvidas frequentes.
+- [Sobre](https://www.analuizarocha.com.br/sobre): Credenciais médicas, formação e contexto clínico.
 
-## High-value treatment pages
-- [Hemorroidas](https://www.analuizarocha.com.br/tratamentos/hemorroidas): Symptoms, diagnosis, and treatment options.
-- [Cirurgia a laser](https://www.analuizarocha.com.br/tratamentos/cx-laser): Laser-based proctologic procedures.
-- [Fistulas anorretais](https://www.analuizarocha.com.br/tratamentos/cx-fistulas-anorretais): Evaluation and surgical management.
-- [Cisto pilonidal](https://www.analuizarocha.com.br/tratamentos/cx-cisto-pilonidal): Treatment pathways and recovery guidance.
-- [Doencas inflamatorias intestinais](https://www.analuizarocha.com.br/tratamentos/doencas-inflamatorias-intestinais): Clinical overview and care options.
-- [HPV anal](https://www.analuizarocha.com.br/tratamentos/hpv-anal): Detection, monitoring, and treatment.
-- [Rastreio de cancer anal](https://www.analuizarocha.com.br/tratamentos/rastreio-cancer-anal): Risk factors and prevention.
-- [Sindrome do intestino irritavel](https://www.analuizarocha.com.br/tratamentos/sindrome-intestino-irritavel): Symptoms and multidisciplinary treatment.
-- [Toxina botulinica](https://www.analuizarocha.com.br/tratamentos/toxina-botulinica): Indications and expected outcomes.
+## Tratamentos prioritários
+- [Hemorroidas](https://www.analuizarocha.com.br/tratamentos/hemorroidas): Sintomas, diagnóstico e opções de tratamento.
+- [Cirurgia a laser](https://www.analuizarocha.com.br/tratamentos/cx-laser): Procedimentos proctológicos com tecnologia a laser.
+- [Fístulas anorretais](https://www.analuizarocha.com.br/tratamentos/cx-fistulas-anorretais): Avaliação e manejo cirúrgico especializado.
+- [Cisto pilonidal](https://www.analuizarocha.com.br/tratamentos/cx-cisto-pilonidal): Abordagens terapêuticas e recuperação.
+- [Doenças inflamatórias intestinais](https://www.analuizarocha.com.br/tratamentos/doencas-inflamatorias-intestinais): Diagnóstico e acompanhamento clínico.
+- [HPV anal](https://www.analuizarocha.com.br/tratamentos/hpv-anal): Rastreio, monitoramento e tratamento.
+- [Rastreio de câncer anal](https://www.analuizarocha.com.br/tratamentos/rastreio-cancer-anal): Fatores de risco e prevenção.
+- [Síndrome do intestino irritável](https://www.analuizarocha.com.br/tratamentos/sindrome-intestino-irritavel): Sintomas e tratamento multidisciplinar.
+- [Toxina botulínica](https://www.analuizarocha.com.br/tratamentos/toxina-botulinica): Indicações e expectativas de resultado.
 
-## Technical sources
-- [Sitemap](https://www.analuizarocha.com.br/sitemap.xml): Canonical URL inventory.
+## Fontes técnicas
+- [Sitemap](https://www.analuizarocha.com.br/sitemap.xml): Inventário canônico de URLs para descoberta de conteúdo.
 
-## Optional
-- [Privacy policy](https://www.analuizarocha.com.br/politica-privacidade): Legal and privacy information.
+## Opcional
+- [Política de privacidade](https://www.analuizarocha.com.br/politica-privacidade): Informações legais e de proteção de dados.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,17 +1,33 @@
+# Global crawl policy
 User-agent: *
 Allow: /
 
-# Sitemap
+# Canonical sitemap
 Sitemap: https://www.analuizarocha.com.br/sitemap.xml
 
-# Crawl delay for polite crawling
-Crawl-delay: 1
-
-# Allow all images
-User-agent: Googlebot-Image
-Allow: /images/
-
-# Medical content - ensure proper indexing
-User-agent: Googlebot
+# OpenAI crawlers
+User-agent: OAI-SearchBot
 Allow: /
-Allow: /images/
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: GPTBot
+Allow: /
+
+# Anthropic crawlers
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: Claude-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+# Perplexity crawlers
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next'
 import {
   HeroSection,
   ServicesSection,
@@ -8,6 +9,20 @@ import {
   AboutSection,
 } from '@/components/sections'
 import { getFAQSchema } from '@/lib/faq-schema'
+import { WEBSITE_URL } from '@/lib/constants'
+
+const HOME_PAGE_TITLE = 'Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba'
+
+export const metadata: Metadata = {
+  title: {
+    absolute: HOME_PAGE_TITLE,
+  },
+  description:
+    'Dra. Ana Luiza M. Rocha, coloproctologista em Curitiba - PR. Cuidado clínico e cirúrgico do intestino, reto e ânus na Clínica Nassif, no Batel.',
+  alternates: {
+    canonical: WEBSITE_URL,
+  },
+}
 
 export default function Home() {
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from 'next'
 import {
   HeroSection,
   ServicesSection,
@@ -9,20 +8,6 @@ import {
   AboutSection,
 } from '@/components/sections'
 import { getFAQSchema } from '@/lib/faq-schema'
-import { WEBSITE_URL } from '@/lib/constants'
-
-const HOME_PAGE_TITLE = 'Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba'
-
-export const metadata: Metadata = {
-  title: {
-    absolute: HOME_PAGE_TITLE,
-  },
-  description:
-    'Dra. Ana Luiza M. Rocha, coloproctologista em Curitiba - PR. Cuidado clínico e cirúrgico do intestino, reto e ânus na Clínica Nassif, no Batel.',
-  alternates: {
-    canonical: WEBSITE_URL,
-  },
-}
 
 export default function Home() {
   return (


### PR DESCRIPTION
## Summary
- update public/robots.txt with explicit allow rules for OpenAI, Anthropic, and Perplexity crawlers
- add public/llms.txt in llmstxt-compatible markdown format
- keep existing sitemap signal in robots for crawler discovery

## Why
- improve compatibility with AI search crawlers while preserving explicit crawl intent
- provide an optional curated content map for tools that read llms.txt

## Validation
- npm run build