### PR TITLE
feat(seo): connect treatment pages with related blog content

### DIFF
--- a/docs/seo-keywords-tracking.csv
+++ b/docs/seo-keywords-tracking.csv
@@ -1,0 +1,366 @@
+keyword,cluster,content_type,source,intent,audience,target_url,priority
+cirurgia laser hemorroidas curitiba,Cirurgia a Laser Proctológica,treatment-page,metadata-keywords,decision,patients,/tratamentos/cx-laser,P1
+cirurgia minimamente invasiva curitiba,Cirurgia a Laser Proctológica,treatment-page,metadata-keywords,decision,patients,/tratamentos/cx-laser,P1
+fissura anal laser curitiba,Cirurgia a Laser Proctológica,treatment-page,metadata-keywords,decision,patients,/tratamentos/cx-laser,P1
+proctologista laser curitiba,Cirurgia a Laser Proctológica,treatment-page,metadata-keywords,decision,patients,/tratamentos/cx-laser,P1
+cirurgia cisto pilonidal curitiba,Cisto Pilonidal,treatment-page,metadata-keywords,decision,patients,/tratamentos/cx-cisto-pilonidal,P1
+cirurgia coccix curitiba,Cisto Pilonidal,treatment-page,metadata-keywords,decision,patients,/tratamentos/cx-cisto-pilonidal,P1
+cisto pilonidal laser curitiba,Cisto Pilonidal,treatment-page,metadata-keywords,decision,patients,/tratamentos/cx-cisto-pilonidal,P1
+cisto sacrococcigeo curitiba,Cisto Pilonidal,treatment-page,metadata-keywords,decision,patients,/tratamentos/cx-cisto-pilonidal,P1
+crm pr 45351,credenciais-medicas,doctor-profile,doctor-credentials,decision,patients,/sobre,P1
+crm pr 45351 rqe 36221,credenciais-medicas,doctor-profile,doctor-credentials,decision,patients,/sobre,P1
+rqe 36221 coloproctologia,credenciais-medicas,doctor-profile,doctor-credentials,decision,patients,/sobre,P1
+DII curitiba,DII,treatment-page,metadata-keywords,decision,patients,/tratamentos/doencas-inflamatorias-intestinais,P1
+doença de crohn curitiba,DII,treatment-page,metadata-keywords,decision,patients,/tratamentos/doencas-inflamatorias-intestinais,P1
+doenças inflamatórias intestinais curitiba,DII,treatment-page,metadata-keywords,decision,patients,/tratamentos/doencas-inflamatorias-intestinais,P1
+retocolite ulcerativa curitiba,DII,treatment-page,metadata-keywords,decision,patients,/tratamentos/doencas-inflamatorias-intestinais,P1
+tratamento crohn curitiba,DII,treatment-page,metadata-keywords,decision,patients,/tratamentos/doencas-inflamatorias-intestinais,P1
+cirurgia fistula anal curitiba,Fístula Anal,treatment-page,metadata-keywords,decision,patients,/tratamentos/cx-fistulas-anorretais,P1
+fistulotomia curitiba,Fístula Anal,treatment-page,metadata-keywords,decision,patients,/tratamentos/cx-fistulas-anorretais,P1
+LIFT cirurgia curitiba,Fístula Anal,treatment-page,metadata-keywords,decision,patients,/tratamentos/cx-fistulas-anorretais,P1
+seton fistula anal curitiba,Fístula Anal,treatment-page,metadata-keywords,decision,patients,/tratamentos/cx-fistulas-anorretais,P1
+cirurgia hemorroidas laser curitiba,Hemorroidas,treatment-page,metadata-keywords,decision,patients,/tratamentos/hemorroidas,P1
+hemorroidectomia curitiba,Hemorroidas,treatment-page,metadata-keywords,decision,patients,/tratamentos/hemorroidas,P1
+ligadura elástica curitiba,Hemorroidas,treatment-page,metadata-keywords,decision,patients,/tratamentos/hemorroidas,P1
+THD curitiba,Hemorroidas,treatment-page,metadata-keywords,decision,patients,/tratamentos/hemorroidas,P1
+tratamento hemorroidas curitiba,Hemorroidas,treatment-page,metadata-keywords,decision,patients,/tratamentos/hemorroidas,P1
+condiloma anal curitiba,HPV Anal,treatment-page,metadata-keywords,decision,patients,/tratamentos/hpv-anal,P1
+tratamento HPV anal curitiba,HPV Anal,treatment-page,metadata-keywords,decision,patients,/tratamentos/hpv-anal,P1
+verrugas anais curitiba,HPV Anal,treatment-page,metadata-keywords,decision,patients,/tratamentos/hpv-anal,P1
+agendar consulta coloproctologista curitiba,landing-homepage,landing-page,landing-copy,decision,patients,/,P1
+cirurgia colorretal curitiba,landing-homepage,landing-page,landing-copy,decision,patients,/,P1
+coloproctologista curitiba batel,landing-homepage,landing-page,landing-copy,decision,patients,/,P1
+consulta coloproctologista curitiba,landing-homepage,landing-page,landing-copy,decision,patients,/,P1
+consultório médico coloproctologia curitiba,landing-homepage,landing-page,landing-copy,decision,patients,/,P1
+proctologia curitiba,landing-homepage,landing-page,landing-copy,decision,patients,/,P1
+proctologista curitiba batel,landing-homepage,landing-page,landing-copy,decision,patients,/,P1
+clínica nassif batel curitiba,landing-locais,landing-page,landing-copy,decision,patients,/,P1
+crm-pr 45351,landing-marca,landing-page,landing-copy,decision,patients,/,P1
+dra ana luiza moraes rocha coloproctologista curitiba,landing-marca,landing-page,landing-copy,decision,patients,/,P1
+dra ana luiza moraes rocha proctologista curitiba,landing-marca,landing-page,landing-copy,decision,patients,/,P1
+rqe 36221,landing-marca,landing-page,landing-copy,decision,patients,/,P1
+cirurgias a laser proctologia curitiba,landing-tratamentos,landing-page,landing-copy,decision,patients,/,P1
+ligadura elástica para hemorroidas curitiba,landing-tratamentos,landing-page,landing-copy,decision,patients,/,P1
+rastreio câncer de canal anal curitiba,landing-tratamentos,landing-page,landing-copy,decision,patients,/,P1
+toxina botulínica para fissura anal curitiba,landing-tratamentos,landing-page,landing-copy,decision,patients,/,P1
+tratamento de hpv curitiba,landing-tratamentos,landing-page,landing-copy,decision,patients,/,P1
+ana luiza moraes rocha,marca-dra-ana-luiza,doctor-profile,doctor-name,decision,patients,/sobre,P1
+ana luiza rocha coloproctologista,marca-dra-ana-luiza,doctor-profile,doctor-name,decision,patients,/sobre,P1
+dra ana luiza m rocha,marca-dra-ana-luiza,doctor-profile,doctor-name,decision,patients,/sobre,P1
+dra ana luiza moraes rocha,marca-dra-ana-luiza,doctor-profile,doctor-name,decision,patients,/sobre,P1
+médica coloproctologista curitiba,marca-dra-ana-luiza,doctor-profile,doctor-name,decision,patients,/sobre,P1
+proctologista dra ana luiza curitiba,marca-dra-ana-luiza,doctor-profile,doctor-name,decision,patients,/sobre,P1
+anuscopia alta resolução curitiba,Rastreio de Câncer Anal e HPV,treatment-page,metadata-keywords,decision,patients,/tratamentos/rastreio-cancer-anal,P1
+citologia anal curitiba,Rastreio de Câncer Anal e HPV,treatment-page,metadata-keywords,decision,patients,/tratamentos/rastreio-cancer-anal,P1
+rastreio cancer anal curitiba,Rastreio de Câncer Anal e HPV,treatment-page,metadata-keywords,decision,patients,/tratamentos/rastreio-cancer-anal,P1
+coloproctologista SII curitiba,Síndrome do Intestino Irritável (SII),treatment-page,metadata-keywords,decision,patients,/tratamentos/sindrome-intestino-irritavel,P1
+SII curitiba,Síndrome do Intestino Irritável (SII),treatment-page,metadata-keywords,decision,patients,/tratamentos/sindrome-intestino-irritavel,P1
+sindrome intestino irritavel curitiba,Síndrome do Intestino Irritável (SII),treatment-page,metadata-keywords,decision,patients,/tratamentos/sindrome-intestino-irritavel,P1
+botox fissura anal curitiba,Toxina Botulínica para Fissura Anal,treatment-page,metadata-keywords,decision,patients,/tratamentos/toxina-botulinica,P1
+dor anal cronica curitiba,Toxina Botulínica para Fissura Anal,treatment-page,metadata-keywords,decision,patients,/tratamentos/toxina-botulinica,P1
+esfíncter anal curitiba,Toxina Botulínica para Fissura Anal,treatment-page,metadata-keywords,decision,patients,/tratamentos/toxina-botulinica,P1
+toxina botulinica anal curitiba,Toxina Botulínica para Fissura Anal,treatment-page,metadata-keywords,decision,patients,/tratamentos/toxina-botulinica,P1
+cirurgia hemorroidas curitiba,tratamentos coloproctologia,treatment-hub,metadata-keywords,decision,patients,/tratamentos,P1
+cirurgia laser curitiba,tratamentos coloproctologia,treatment-hub,metadata-keywords,decision,patients,/tratamentos,P1
+cisto pilonidal curitiba,tratamentos coloproctologia,treatment-hub,metadata-keywords,decision,patients,/tratamentos,P1
+coloproctologia curitiba,tratamentos coloproctologia,treatment-hub,metadata-keywords,decision,patients,/tratamentos,P1
+HPV anal curitiba,tratamentos coloproctologia,treatment-hub,metadata-keywords,decision,patients,/tratamentos,P1
+proctologista curitiba,tratamentos coloproctologia,treatment-hub,metadata-keywords,decision,patients,/tratamentos,P1
+tratamento fissura anal,tratamentos coloproctologia,treatment-hub,metadata-keywords,decision,patients,/tratamentos,P1
+acompanhamento coloproctológico,acompanhamento especializado,blog-post,blog-secondary,consideration,patients,/blog/o-que-muda-acompanhamento-especializado-coloproctologista-curitiba,P2
+acompanhamento especializado,acompanhamento especializado,blog-post,blog-primary,consideration,patients,/blog/o-que-muda-acompanhamento-especializado-coloproctologista-curitiba,P2
+coloproctologista em Curitiba,acompanhamento especializado,blog-post,blog-secondary,consideration,patients,/blog/o-que-muda-acompanhamento-especializado-coloproctologista-curitiba,P2
+prevenção de recorrências intestinais,acompanhamento especializado,blog-post,blog-secondary,consideration,patients,/blog/o-que-muda-acompanhamento-especializado-coloproctologista-curitiba,P2
+saúde intestinal a longo prazo,acompanhamento especializado,blog-post,blog-secondary,consideration,patients,/blog/o-que-muda-acompanhamento-especializado-coloproctologista-curitiba,P2
+tratamento intestinal individualizado,acompanhamento especializado,blog-post,blog-secondary,consideration,patients,/blog/o-que-muda-acompanhamento-especializado-coloproctologista-curitiba,P2
+artigos coloproctologista curitiba,blog coloproctologia,blog-hub,metadata-keywords,awareness,general-public,/blog,P2
+coloproctologista Curitiba,câncer colorretal,blog-post,blog-secondary,awareness,patients,/blog/cancer-colorretal-rastreio-prevencao-diagnostico-precoce,P2
+cirurgia a laser proctológica,Cirurgia a Laser Proctológica,treatment-page,title-topic,decision,patients,/tratamentos/cx-laser,P2
+coloproctologia laser,Cirurgia a Laser Proctológica,treatment-page,metadata-keywords,decision,patients,/tratamentos/cx-laser,P2
+abscesso sacrococcígeo,cisto pilonidal,blog-post,blog-secondary,consideration,patients,/blog/cisto-pilonidal-cirurgia-laser-quando-operar,P2
+cirurgia a laser cisto pilonidal,cisto pilonidal,blog-post,blog-secondary,consideration,patients,/blog/cisto-pilonidal-cirurgia-laser-quando-operar,P2
+cisto pilonidal,cisto pilonidal,blog-post,blog-primary,consideration,patients,/blog/cisto-pilonidal-cirurgia-laser-quando-operar,P2
+drenagem x cirurgia definitiva,cisto pilonidal,blog-post,blog-secondary,consideration,patients,/blog/cisto-pilonidal-cirurgia-laser-quando-operar,P2
+recidiva cisto pilonidal,cisto pilonidal,blog-post,blog-secondary,consideration,patients,/blog/cisto-pilonidal-cirurgia-laser-quando-operar,P2
+cisto pilonidal,Cisto Pilonidal,treatment-page,title-topic,decision,patients,/tratamentos/cx-cisto-pilonidal,P2
+laser pilonidal,Cisto Pilonidal,treatment-page,metadata-keywords,decision,patients,/tratamentos/cx-cisto-pilonidal,P2
+tratamento cisto pilonidal,Cisto Pilonidal,treatment-page,metadata-keywords,decision,patients,/tratamentos/cx-cisto-pilonidal,P2
+coloproctologista Curitiba,coceira anal,blog-post,blog-secondary,awareness,patients,/blog/coceira-anal-quando-procurar-coloproctologista-curitiba,P2
+coloproctologista Curitiba,constipação intestinal crônica,blog-post,blog-secondary,awareness,patients,/blog/constipacao-intestinal-cronica-causas-tratamento,P2
+diarreia crônica,diarreia crônica,blog-post,blog-primary,consideration,patients,/blog/diarreia-cronica-tratamento,P2
+diarreia nervosa,diarreia crônica,blog-post,blog-secondary,consideration,patients,/blog/diarreia-cronica-tratamento,P2
+exames diarreia,diarreia crônica,blog-post,blog-secondary,consideration,patients,/blog/diarreia-cronica-tratamento,P2
+intestino solto,diarreia crônica,blog-post,blog-secondary,consideration,patients,/blog/diarreia-cronica-tratamento,P2
+síndrome intestino irritável,diarreia crônica,blog-post,blog-secondary,consideration,patients,/blog/diarreia-cronica-tratamento,P2
+coloproctologista DII,DII,treatment-page,metadata-keywords,decision,patients,/tratamentos/doencas-inflamatorias-intestinais,P2
+dii,DII,treatment-page,title-topic,decision,patients,/tratamentos/doencas-inflamatorias-intestinais,P2
+coloproctologista Curitiba,distúrbios do assoalho pélvico,blog-post,blog-secondary,awareness,patients,/blog/disturbios-assoalho-pelvico-funcionamento-intestino,P2
+acompanhamento DII,doenças inflamatórias intestinais,blog-post,blog-secondary,consideration,patients,/blog/doencas-inflamatorias-intestinais-acompanhamento,P2
+coloproctologista Curitiba,doenças inflamatórias intestinais,blog-post,blog-secondary,consideration,patients,/blog/doencas-inflamatorias-intestinais-acompanhamento,P2
+Doença de Crohn,doenças inflamatórias intestinais,blog-post,blog-secondary,consideration,patients,/blog/doencas-inflamatorias-intestinais-acompanhamento,P2
+doenças inflamatórias intestinais,doenças inflamatórias intestinais,blog-post,blog-primary,consideration,patients,/blog/doencas-inflamatorias-intestinais-acompanhamento,P2
+Retocolite Ulcerativa,doenças inflamatórias intestinais,blog-post,blog-secondary,consideration,patients,/blog/doencas-inflamatorias-intestinais-acompanhamento,P2
+tratamento DII,doenças inflamatórias intestinais,blog-post,blog-secondary,consideration,patients,/blog/doencas-inflamatorias-intestinais-acompanhamento,P2
+dor anal curitiba,fissura anal,blog-post,blog-secondary,consideration,patients,/blog/fissura-anal-tratamento,P2
+dor ao evacuar,fissura anal,blog-post,blog-secondary,consideration,patients,/blog/fissura-anal-tratamento,P2
+esfincterotomia,fissura anal,blog-post,blog-secondary,consideration,patients,/blog/fissura-anal-tratamento,P2
+fissura anal,fissura anal,blog-post,blog-primary,consideration,patients,/blog/fissura-anal-tratamento,P2
+fissura anal curitiba,fissura anal,blog-post,blog-secondary,consideration,patients,/blog/fissura-anal-tratamento,P2
+sangramento anal curitiba,fissura anal,blog-post,blog-secondary,consideration,patients,/blog/fissura-anal-tratamento,P2
+toxina botulínica fissura,fissura anal,blog-post,blog-secondary,consideration,patients,/blog/fissura-anal-tratamento,P2
+coloproctologista Curitiba,fístula anal,blog-post,blog-secondary,consideration,patients,/blog/tratamento-fistulas-anorretais,P2
+fístula anal,fístula anal,blog-post,blog-primary,consideration,patients,/blog/tratamento-fistulas-anorretais,P2
+fístulas anorretais,fístula anal,blog-post,blog-secondary,consideration,patients,/blog/tratamento-fistulas-anorretais,P2
+seton,fístula anal,blog-post,blog-secondary,consideration,patients,/blog/tratamento-fistulas-anorretais,P2
+técnica LIFT,fístula anal,blog-post,blog-secondary,consideration,patients,/blog/tratamento-fistulas-anorretais,P2
+tratamento fístula anal,fístula anal,blog-post,blog-secondary,consideration,patients,/blog/tratamento-fistulas-anorretais,P2
+fístula anal,Fístula Anal,treatment-page,title-topic,decision,patients,/tratamentos/cx-fistulas-anorretais,P2
+laser fistula anal,Fístula Anal,treatment-page,metadata-keywords,decision,patients,/tratamentos/cx-fistulas-anorretais,P2
+retalho mucoso fistula,Fístula Anal,treatment-page,metadata-keywords,decision,patients,/tratamentos/cx-fistulas-anorretais,P2
+anuscopia de alta resolução curitiba,formacao-medica,doctor-profile,doctor-credentials,decision,patients,/sobre,P2
+fellow cirurgia colorretal barcelona,formacao-medica,doctor-profile,doctor-credentials,consideration,patients,/sobre,P2
+hospital clinic barcelona cirurgia colorretal,formacao-medica,doctor-profile,doctor-credentials,consideration,patients,/sobre,P2
+hospital santa casa de curitiba cirurgia geral,formacao-medica,doctor-profile,doctor-credentials,consideration,patients,/sobre,P2
+hospital universitário evangélico mackenzie coloproctologia,formacao-medica,doctor-profile,doctor-credentials,consideration,patients,/sobre,P2
+international anal neoplasia society,formacao-medica,doctor-profile,doctor-credentials,consideration,patients,/sobre,P2
+membro ians coloproctologia,formacao-medica,doctor-profile,doctor-credentials,consideration,patients,/sobre,P2
+mestranda ufpr clínica cirúrgica,formacao-medica,doctor-profile,doctor-credentials,consideration,patients,/sobre,P2
+puc-pr medicina,formacao-medica,doctor-profile,doctor-credentials,consideration,patients,/sobre,P2
+cirurgia hemorroida laser,hemorroida é cirúrgica,blog-post,blog-secondary,consideration,patients,/blog/hemorroida-sempre-cirurgica-tratamento,P2
+coloproctologista Curitiba,hemorroida é cirúrgica,blog-post,blog-secondary,consideration,patients,/blog/hemorroida-sempre-cirurgica-tratamento,P2
+hemorroida é cirúrgica,hemorroida é cirúrgica,blog-post,blog-primary,consideration,patients,/blog/hemorroida-sempre-cirurgica-tratamento,P2
+hemorroida interna externa,hemorroida é cirúrgica,blog-post,blog-secondary,consideration,patients,/blog/hemorroida-sempre-cirurgica-tratamento,P2
+ligadura elástica hemorroida,hemorroida é cirúrgica,blog-post,blog-secondary,consideration,patients,/blog/hemorroida-sempre-cirurgica-tratamento,P2
+tratamento hemorroida,hemorroida é cirúrgica,blog-post,blog-secondary,consideration,patients,/blog/hemorroida-sempre-cirurgica-tratamento,P2
+escleroterapia hemorroidas,Hemorroidas,treatment-page,metadata-keywords,decision,patients,/tratamentos/hemorroidas,P2
+hemorroidas,Hemorroidas,treatment-page,title-topic,decision,patients,/tratamentos/hemorroidas,P2
+coloproctologista Curitiba,HPV anal,blog-post,blog-secondary,awareness,patients,/blog/hpv-anal-condilomas-riscos-tratamento-rastreio,P2
+eletrocauterização HPV,HPV Anal,treatment-page,metadata-keywords,decision,patients,/tratamentos/hpv-anal,P2
+hpv anal,HPV Anal,treatment-page,title-topic,decision,patients,/tratamentos/hpv-anal,P2
+imiquimode condiloma,HPV Anal,treatment-page,metadata-keywords,decision,patients,/tratamentos/hpv-anal,P2
+laser HPV anal,HPV Anal,treatment-page,metadata-keywords,decision,patients,/tratamentos/hpv-anal,P2
+atendimento humanizado coloproctologia curitiba,landing-homepage,landing-page,landing-copy,decision,patients,/,P2
+colonoscopia curitiba mercês,landing-locais,landing-page,landing-copy,decision,patients,/,P2
+specta endoscopia digestiva curitiba,landing-locais,landing-page,landing-copy,consideration,patients,/,P2
+cisto pilonidal curitiba,landing-sintomas-condicoes,landing-page,landing-copy,consideration,patients,/,P2
+coceira anal curitiba,landing-sintomas-condicoes,landing-page,landing-copy,awareness,patients,/,P2
+constipação intestinal curitiba,landing-sintomas-condicoes,landing-page,landing-copy,awareness,patients,/,P2
+diarreia crônica curitiba,landing-sintomas-condicoes,landing-page,landing-copy,consideration,patients,/,P2
+distúrbios do assoalho pélvico curitiba,landing-sintomas-condicoes,landing-page,landing-copy,awareness,patients,/,P2
+doenças inflamatórias intestinais curitiba,landing-sintomas-condicoes,landing-page,landing-copy,consideration,patients,/,P2
+fissura anal curitiba,landing-sintomas-condicoes,landing-page,landing-copy,consideration,patients,/,P2
+fístula anal curitiba,landing-sintomas-condicoes,landing-page,landing-copy,consideration,patients,/,P2
+hemorroidas curitiba,landing-sintomas-condicoes,landing-page,landing-copy,consideration,patients,/,P2
+hpv anal curitiba,landing-sintomas-condicoes,landing-page,landing-copy,consideration,patients,/,P2
+prurido anal curitiba,landing-sintomas-condicoes,landing-page,landing-copy,awareness,patients,/,P2
+síndrome do intestino irritável curitiba,landing-sintomas-condicoes,landing-page,landing-copy,consideration,patients,/,P2
+tratamentos minimamente invasivos coloproctologia,landing-tratamentos,landing-page,landing-copy,consideration,patients,/,P2
+cirurgia a laser plicoma,plicoma anal,blog-post,blog-secondary,consideration,patients,/blog/plicoma-anal-cirurgia-laser,P2
+higiene anal difícil,plicoma anal,blog-post,blog-secondary,consideration,patients,/blog/plicoma-anal-cirurgia-laser,P2
+plicoma anal,plicoma anal,blog-post,blog-primary,consideration,patients,/blog/plicoma-anal-cirurgia-laser,P2
+recuperação plicoma,plicoma anal,blog-post,blog-secondary,consideration,patients,/blog/plicoma-anal-cirurgia-laser,P2
+sobras de pele anal,plicoma anal,blog-post,blog-secondary,consideration,patients,/blog/plicoma-anal-cirurgia-laser,P2
+coloproctologista Curitiba,quando procurar coloproctologista,blog-post,blog-secondary,awareness,patients,/blog/quando-procurar-coloproctologista-curitiba,P2
+médico intestino Curitiba,quando procurar coloproctologista,blog-post,blog-secondary,awareness,patients,/blog/quando-procurar-coloproctologista-curitiba,P2
+proctologista Curitiba,quando procurar coloproctologista,blog-post,blog-secondary,awareness,patients,/blog/quando-procurar-coloproctologista-curitiba,P2
+HPV canal anal,Rastreio de Câncer Anal e HPV,treatment-page,metadata-keywords,decision,patients,/tratamentos/rastreio-cancer-anal,P2
+IANS coloproctologia,Rastreio de Câncer Anal e HPV,treatment-page,metadata-keywords,decision,patients,/tratamentos/rastreio-cancer-anal,P2
+prevenção cancer anal,Rastreio de Câncer Anal e HPV,treatment-page,metadata-keywords,decision,patients,/tratamentos/rastreio-cancer-anal,P2
+rastreio de câncer anal e hpv,Rastreio de Câncer Anal e HPV,treatment-page,title-topic,decision,patients,/tratamentos/rastreio-cancer-anal,P2
+coloproctologista Curitiba,sangue nas fezes,blog-post,blog-secondary,awareness,patients,/blog/sangue-nas-fezes-quando-procurar-coloproctologista,P2
+coloproctologista Curitiba,saúde sexual,blog-post,blog-secondary,awareness,patients,/blog/saude-sexual-cuidado-informacao-bem-estar,P2
+coloproctologista em Curitiba,sinais de alerta intestinais,blog-post,blog-secondary,awareness,patients,/blog/quando-intestino-da-sinais-de-alerta-coloproctologista-curitiba,P2
+coloproctologista Curitiba,síndrome do intestino irritável,blog-post,blog-secondary,awareness,patients,/blog/sindrome-intestino-irritavel-sintomas-diagnostico-tratamento,P2
+disturbio funcional intestinal,Síndrome do Intestino Irritável (SII),treatment-page,metadata-keywords,decision,patients,/tratamentos/sindrome-intestino-irritavel,P2
+dor abdominal cronica,Síndrome do Intestino Irritável (SII),treatment-page,metadata-keywords,decision,patients,/tratamentos/sindrome-intestino-irritavel,P2
+intestino irritavel tratamento,Síndrome do Intestino Irritável (SII),treatment-page,metadata-keywords,decision,patients,/tratamentos/sindrome-intestino-irritavel,P2
+síndrome do intestino irritável (sii),Síndrome do Intestino Irritável (SII),treatment-page,title-topic,decision,patients,/tratamentos/sindrome-intestino-irritavel,P2
+coloproctologista em Curitiba,sintomas intestinais persistentes,blog-post,blog-secondary,consideration,patients,/blog/por-que-meus-sintomas-nunca-melhoram,P2
+exames normais e sintomas,sintomas intestinais persistentes,blog-post,blog-secondary,consideration,patients,/blog/por-que-meus-sintomas-nunca-melhoram,P2
+hemorroidas recorrentes,sintomas intestinais persistentes,blog-post,blog-secondary,consideration,patients,/blog/por-que-meus-sintomas-nunca-melhoram,P2
+intestino desregulado,sintomas intestinais persistentes,blog-post,blog-secondary,consideration,patients,/blog/por-que-meus-sintomas-nunca-melhoram,P2
+laxantes irritativos,sintomas intestinais persistentes,blog-post,blog-secondary,consideration,patients,/blog/por-que-meus-sintomas-nunca-melhoram,P2
+sintomas intestinais persistentes,sintomas intestinais persistentes,blog-post,blog-primary,consideration,patients,/blog/por-que-meus-sintomas-nunca-melhoram,P2
+procedimento minimamente invasivo,Toxina Botulínica para Fissura Anal,treatment-page,metadata-keywords,decision,patients,/tratamentos/toxina-botulinica,P2
+toxina botulínica para fissura anal,Toxina Botulínica para Fissura Anal,treatment-page,title-topic,decision,patients,/tratamentos/toxina-botulinica,P2
+tratamento fissura anal,Toxina Botulínica para Fissura Anal,treatment-page,metadata-keywords,decision,patients,/tratamentos/toxina-botulinica,P2
+coloproctologista em Curitiba,vergonha de procurar coloproctologista,blog-post,blog-secondary,awareness,patients,/blog/sinto-vergonha-procurar-coloproctologista-isso-e-normal,P2
+acompanhamento significa consulta frequente,acompanhamento especializado,blog-post,faq-question,consideration,patients,/blog/o-que-muda-acompanhamento-especializado-coloproctologista-curitiba,P3
+o acompanhamento evita cirurgia,acompanhamento especializado,blog-post,faq-question,consideration,patients,/blog/o-que-muda-acompanhamento-especializado-coloproctologista-curitiba,P3
+preciso retornar mesmo se estiver melhor,acompanhamento especializado,blog-post,faq-question,consideration,patients,/blog/o-que-muda-acompanhamento-especializado-coloproctologista-curitiba,P3
+vale a pena mesmo quando o problema parece simples,acompanhamento especializado,blog-post,faq-question,consideration,patients,/blog/o-que-muda-acompanhamento-especializado-coloproctologista-curitiba,P3
+alimentação e saúde intestinal,alimentação e saúde intestinal,blog-post,blog-primary,awareness,patients,/blog/alimentacao-e-saude-intestinal,P3
+beber mais água ajuda meu intestino,alimentação e saúde intestinal,blog-post,faq-question,awareness,patients,/blog/alimentacao-e-saude-intestinal,P3
+como melhorar o intestino,alimentação e saúde intestinal,blog-post,blog-secondary,awareness,patients,/blog/alimentacao-e-saude-intestinal,P3
+dieta para constipação,alimentação e saúde intestinal,blog-post,blog-secondary,awareness,patients,/blog/alimentacao-e-saude-intestinal,P3
+fibras intestino,alimentação e saúde intestinal,blog-post,blog-secondary,awareness,patients,/blog/alimentacao-e-saude-intestinal,P3
+hidratação e intestino,alimentação e saúde intestinal,blog-post,blog-secondary,awareness,patients,/blog/alimentacao-e-saude-intestinal,P3
+posso usar laxantes naturais todos os dias,alimentação e saúde intestinal,blog-post,faq-question,awareness,patients,/blog/alimentacao-e-saude-intestinal,P3
+quanta fibra devo consumir por dia,alimentação e saúde intestinal,blog-post,faq-question,awareness,patients,/blog/alimentacao-e-saude-intestinal,P3
+ritmo intestinal,alimentação e saúde intestinal,blog-post,blog-secondary,awareness,patients,/blog/alimentacao-e-saude-intestinal,P3
+blog coloproctologia,blog coloproctologia,blog-hub,metadata-keywords,awareness,general-public,/blog,P3
+cirurgia laser coloproctologia,blog coloproctologia,blog-hub,metadata-keywords,awareness,general-public,/blog,P3
+cisto pilonidal,blog coloproctologia,blog-hub,metadata-keywords,awareness,general-public,/blog,P3
+plicoma anal,blog coloproctologia,blog-hub,metadata-keywords,awareness,general-public,/blog,P3
+prevenção câncer colorretal,blog coloproctologia,blog-hub,metadata-keywords,awareness,general-public,/blog,P3
+saúde intestinal,blog coloproctologia,blog-hub,metadata-keywords,awareness,general-public,/blog,P3
+tratamento hemorroidas,blog coloproctologia,blog-hub,metadata-keywords,awareness,general-public,/blog,P3
+a colonoscopia é segura,câncer colorretal,blog-post,faq-question,awareness,patients,/blog/cancer-colorretal-rastreio-prevencao-diagnostico-precoce,P3
+câncer colorretal,câncer colorretal,blog-post,blog-primary,awareness,patients,/blog/cancer-colorretal-rastreio-prevencao-diagnostico-precoce,P3
+colonoscopia preventiva,câncer colorretal,blog-post,blog-secondary,awareness,patients,/blog/cancer-colorretal-rastreio-prevencao-diagnostico-precoce,P3
+com que frequência devo repetir a colonoscopia,câncer colorretal,blog-post,faq-question,awareness,patients,/blog/cancer-colorretal-rastreio-prevencao-diagnostico-precoce,P3
+diagnóstico precoce câncer de intestino,câncer colorretal,blog-post,blog-secondary,awareness,patients,/blog/cancer-colorretal-rastreio-prevencao-diagnostico-precoce,P3
+o rastreio é necessário mesmo sem sintomas,câncer colorretal,blog-post,faq-question,awareness,patients,/blog/cancer-colorretal-rastreio-prevencao-diagnostico-precoce,P3
+pólipos intestinais,câncer colorretal,blog-post,blog-secondary,awareness,patients,/blog/cancer-colorretal-rastreio-prevencao-diagnostico-precoce,P3
+rastreio câncer colorretal,câncer colorretal,blog-post,blog-secondary,awareness,patients,/blog/cancer-colorretal-rastreio-prevencao-diagnostico-precoce,P3
+se eu tiver pólipos é câncer,câncer colorretal,blog-post,faq-question,awareness,patients,/blog/cancer-colorretal-rastreio-prevencao-diagnostico-precoce,P3
+a cirurgia a laser dói,cisto pilonidal,blog-post,faq-question,consideration,patients,/blog/cisto-pilonidal-cirurgia-laser-quando-operar,P3
+o cisto pilonidal some sozinho,cisto pilonidal,blog-post,faq-question,consideration,patients,/blog/cisto-pilonidal-cirurgia-laser-quando-operar,P3
+preciso operar mesmo sem sintomas agora,cisto pilonidal,blog-post,faq-question,consideration,patients,/blog/cisto-pilonidal-cirurgia-laser-quando-operar,P3
+quanto tempo para recuperar,cisto pilonidal,blog-post,faq-question,consideration,patients,/blog/cisto-pilonidal-cirurgia-laser-quando-operar,P3
+causas coceira anal,coceira anal,blog-post,blog-secondary,awareness,patients,/blog/coceira-anal-quando-procurar-coloproctologista-curitiba,P3
+coceira anal,coceira anal,blog-post,blog-primary,awareness,patients,/blog/coceira-anal-quando-procurar-coloproctologista-curitiba,P3
+coceira anal é sempre sinal de doença,coceira anal,blog-post,faq-question,awareness,patients,/blog/coceira-anal-quando-procurar-coloproctologista-curitiba,P3
+doenças orificiais,coceira anal,blog-post,blog-secondary,awareness,patients,/blog/coceira-anal-quando-procurar-coloproctologista-curitiba,P3
+é normal ter coceira anal à noite,coceira anal,blog-post,faq-question,awareness,patients,/blog/coceira-anal-quando-procurar-coloproctologista-curitiba,P3
+o que posso fazer para prevenir a coceira anal,coceira anal,blog-post,faq-question,awareness,patients,/blog/coceira-anal-quando-procurar-coloproctologista-curitiba,P3
+posso usar pomadas por conta própria,coceira anal,blog-post,faq-question,awareness,patients,/blog/coceira-anal-quando-procurar-coloproctologista-curitiba,P3
+prurido anal,coceira anal,blog-post,blog-secondary,awareness,patients,/blog/coceira-anal-quando-procurar-coloproctologista-curitiba,P3
+tratamento prurido anal,coceira anal,blog-post,blog-secondary,awareness,patients,/blog/coceira-anal-quando-procurar-coloproctologista-curitiba,P3
+a prisão de ventre pode causar hemorroidas,constipação intestinal crônica,blog-post,faq-question,awareness,patients,/blog/constipacao-intestinal-cronica-causas-tratamento,P3
+causas constipação intestinal,constipação intestinal crônica,blog-post,blog-secondary,awareness,patients,/blog/constipacao-intestinal-cronica-causas-tratamento,P3
+constipação intestinal crônica,constipação intestinal crônica,blog-post,blog-primary,awareness,patients,/blog/constipacao-intestinal-cronica-causas-tratamento,P3
+posso usar laxantes por conta própria,constipação intestinal crônica,blog-post,faq-question,awareness,patients,/blog/constipacao-intestinal-cronica-causas-tratamento,P3
+prisão de ventre é sempre causada por má alimentação,constipação intestinal crônica,blog-post,faq-question,awareness,patients,/blog/constipacao-intestinal-cronica-causas-tratamento,P3
+prisão de ventre tratamento,constipação intestinal crônica,blog-post,blog-secondary,awareness,patients,/blog/constipacao-intestinal-cronica-causas-tratamento,P3
+quando devo procurar um coloproctologista,constipação intestinal crônica,blog-post,faq-question,awareness,patients,/blog/constipacao-intestinal-cronica-causas-tratamento,P3
+sintomas prisão de ventre,constipação intestinal crônica,blog-post,blog-secondary,awareness,patients,/blog/constipacao-intestinal-cronica-causas-tratamento,P3
+tratamento intestino preso,constipação intestinal crônica,blog-post,blog-secondary,awareness,patients,/blog/constipacao-intestinal-cronica-causas-tratamento,P3
+diarreia crônica pode ser apenas nervosa,diarreia crônica,blog-post,faq-question,consideration,patients,/blog/diarreia-cronica-tratamento,P3
+diarreia crônica pode ser câncer,diarreia crônica,blog-post,faq-question,consideration,patients,/blog/diarreia-cronica-tratamento,P3
+o que devo comer quando estou com diarreia frequente,diarreia crônica,blog-post,faq-question,consideration,patients,/blog/diarreia-cronica-tratamento,P3
+quando a colonoscopia é indicada,diarreia crônica,blog-post,faq-question,consideration,patients,/blog/diarreia-cronica-tratamento,P3
+dieta sozinha é suficiente para tratar sibo,disbiose intestinal,blog-post,faq-question,awareness,patients,/blog/disbiose-sibo-tratamento,P3
+disbiose e sibo são a mesma coisa,disbiose intestinal,blog-post,faq-question,awareness,patients,/blog/disbiose-sibo-tratamento,P3
+disbiose intestinal,disbiose intestinal,blog-post,blog-primary,awareness,patients,/blog/disbiose-sibo-tratamento,P3
+inchaço abdominal tratamento,disbiose intestinal,blog-post,blog-secondary,awareness,patients,/blog/disbiose-sibo-tratamento,P3
+microbiota intestinal,disbiose intestinal,blog-post,blog-secondary,awareness,patients,/blog/disbiose-sibo-tratamento,P3
+probióticos resolvem sibo,disbiose intestinal,blog-post,faq-question,awareness,patients,/blog/disbiose-sibo-tratamento,P3
+sibo sintomas,disbiose intestinal,blog-post,blog-secondary,awareness,patients,/blog/disbiose-sibo-tratamento,P3
+sibo tem cura,disbiose intestinal,blog-post,faq-question,awareness,patients,/blog/disbiose-sibo-tratamento,P3
+supercrescimento bacteriano,disbiose intestinal,blog-post,blog-secondary,awareness,patients,/blog/disbiose-sibo-tratamento,P3
+disfunção evacuatória,distúrbios do assoalho pélvico,blog-post,blog-secondary,awareness,patients,/blog/disturbios-assoalho-pelvico-funcionamento-intestino,P3
+distúrbios do assoalho pélvico,distúrbios do assoalho pélvico,blog-post,blog-primary,awareness,patients,/blog/disturbios-assoalho-pelvico-funcionamento-intestino,P3
+distúrbios do assoalho pélvico têm tratamento,distúrbios do assoalho pélvico,blog-post,faq-question,awareness,patients,/blog/disturbios-assoalho-pelvico-funcionamento-intestino,P3
+esses distúrbios podem piorar com o tempo,distúrbios do assoalho pélvico,blog-post,faq-question,awareness,patients,/blog/disturbios-assoalho-pelvico-funcionamento-intestino,P3
+evacuação incompleta,distúrbios do assoalho pélvico,blog-post,blog-secondary,awareness,patients,/blog/disturbios-assoalho-pelvico-funcionamento-intestino,P3
+fisioterapia pélvica,distúrbios do assoalho pélvico,blog-post,blog-secondary,awareness,patients,/blog/disturbios-assoalho-pelvico-funcionamento-intestino,P3
+fisioterapia pélvica realmente funciona,distúrbios do assoalho pélvico,blog-post,faq-question,awareness,patients,/blog/disturbios-assoalho-pelvico-funcionamento-intestino,P3
+incontinencia fecal,distúrbios do assoalho pélvico,blog-post,blog-secondary,awareness,patients,/blog/disturbios-assoalho-pelvico-funcionamento-intestino,P3
+incontinência fecal é normal com a idade,distúrbios do assoalho pélvico,blog-post,faq-question,awareness,patients,/blog/disturbios-assoalho-pelvico-funcionamento-intestino,P3
+crohn e retocolite ulcerativa são a mesma doença,doenças inflamatórias intestinais,blog-post,faq-question,consideration,patients,/blog/doencas-inflamatorias-intestinais-acompanhamento,P3
+doença de crohn e retocolite ulcerativa têm cura,doenças inflamatórias intestinais,blog-post,faq-question,consideration,patients,/blog/doencas-inflamatorias-intestinais-acompanhamento,P3
+mesmo em remissão preciso continuar acompanhamento,doenças inflamatórias intestinais,blog-post,faq-question,consideration,patients,/blog/doencas-inflamatorias-intestinais-acompanhamento,P3
+todo paciente com dii precisa de cirurgia,doenças inflamatórias intestinais,blog-post,faq-question,consideration,patients,/blog/doencas-inflamatorias-intestinais-acompanhamento,P3
+beber pouca água interfere no efeito das fibras,fibras alimentares,blog-post,faq-question,awareness,general-public,/blog/alimentacao-fibras-saude-intestinal,P3
+comer muita fibra pode causar gases,fibras alimentares,blog-post,faq-question,awareness,general-public,/blog/alimentacao-fibras-saude-intestinal,P3
+constipação tratamento,fibras alimentares,blog-post,blog-secondary,awareness,general-public,/blog/alimentacao-fibras-saude-intestinal,P3
+fibras alimentares,fibras alimentares,blog-post,blog-primary,awareness,general-public,/blog/alimentacao-fibras-saude-intestinal,P3
+fibras solúveis insolúveis,fibras alimentares,blog-post,blog-secondary,awareness,general-public,/blog/alimentacao-fibras-saude-intestinal,P3
+prevenção hemorroidas,fibras alimentares,blog-post,blog-secondary,awareness,general-public,/blog/alimentacao-fibras-saude-intestinal,P3
+qual a quantidade ideal de fibras por dia,fibras alimentares,blog-post,faq-question,awareness,general-public,/blog/alimentacao-fibras-saude-intestinal,P3
+saúde intestinal,fibras alimentares,blog-post,blog-secondary,awareness,general-public,/blog/alimentacao-fibras-saude-intestinal,P3
+suplementos de fibras funcionam,fibras alimentares,blog-post,faq-question,awareness,general-public,/blog/alimentacao-fibras-saude-intestinal,P3
+a cirurgia de fissura anal causa incontinência,fissura anal,blog-post,faq-question,consideration,patients,/blog/fissura-anal-tratamento,P3
+a fissura anal pode cicatrizar sozinha,fissura anal,blog-post,faq-question,consideration,patients,/blog/fissura-anal-tratamento,P3
+quando devo procurar um coloproctologista em curitiba,fissura anal,blog-post,faq-question,consideration,patients,/blog/fissura-anal-tratamento,P3
+quando é indicado o uso de toxina botulínica,fissura anal,blog-post,faq-question,consideration,patients,/blog/fissura-anal-tratamento,P3
+doença de crohn muda o tratamento da fístula,fístula anal,blog-post,faq-question,consideration,patients,/blog/tratamento-fistulas-anorretais,P3
+fístula anal melhora sozinha,fístula anal,blog-post,faq-question,consideration,patients,/blog/tratamento-fistulas-anorretais,P3
+para que serve o seton,fístula anal,blog-post,faq-question,consideration,patients,/blog/tratamento-fistulas-anorretais,P3
+toda fístula precisa de cirurgia,fístula anal,blog-post,faq-question,consideration,patients,/blog/tratamento-fistulas-anorretais,P3
+a ligadura elástica dói,hemorroida é cirúrgica,blog-post,faq-question,consideration,patients,/blog/hemorroida-sempre-cirurgica-tratamento,P3
+hemorroida externa sempre precisa operar,hemorroida é cirúrgica,blog-post,faq-question,consideration,patients,/blog/hemorroida-sempre-cirurgica-tratamento,P3
+posso operar durante uma crise hemorroidária,hemorroida é cirúrgica,blog-post,faq-question,consideration,patients,/blog/hemorroida-sempre-cirurgica-tratamento,P3
+toda hemorroida precisa de cirurgia,hemorroida é cirúrgica,blog-post,faq-question,consideration,patients,/blog/hemorroida-sempre-cirurgica-tratamento,P3
+a vacina funciona em adultos,HPV anal,blog-post,faq-question,awareness,patients,/blog/hpv-anal-condilomas-riscos-tratamento-rastreio,P3
+cancer anal HPV,HPV anal,blog-post,blog-secondary,awareness,patients,/blog/hpv-anal-condilomas-riscos-tratamento-rastreio,P3
+condilomas anais,HPV anal,blog-post,blog-secondary,awareness,patients,/blog/hpv-anal-condilomas-riscos-tratamento-rastreio,P3
+condilomas podem voltar após o tratamento,HPV anal,blog-post,faq-question,awareness,patients,/blog/hpv-anal-condilomas-riscos-tratamento-rastreio,P3
+HPV anal,HPV anal,blog-post,blog-primary,awareness,patients,/blog/hpv-anal-condilomas-riscos-tratamento-rastreio,P3
+hpv anal sempre causa verrugas,HPV anal,blog-post,faq-question,awareness,patients,/blog/hpv-anal-condilomas-riscos-tratamento-rastreio,P3
+hpv anal sempre evolui para câncer,HPV anal,blog-post,faq-question,awareness,patients,/blog/hpv-anal-condilomas-riscos-tratamento-rastreio,P3
+rastreio HPV anal,HPV anal,blog-post,blog-secondary,awareness,patients,/blog/hpv-anal-condilomas-riscos-tratamento-rastreio,P3
+vacina HPV adultos,HPV anal,blog-post,blog-secondary,awareness,patients,/blog/hpv-anal-condilomas-riscos-tratamento-rastreio,P3
+quando procurar coloproctologista,landing-homepage,landing-page,landing-copy,awareness,patients,/,P3
+sinais e sintomas intestinais,landing-homepage,landing-page,landing-copy,awareness,patients,/,P3
+dor ao evacuar,landing-sintomas-condicoes,landing-page,landing-copy,awareness,patients,/,P3
+evacuação incompleta,landing-sintomas-condicoes,landing-page,landing-copy,awareness,patients,/,P3
+incontinência fecal,landing-sintomas-condicoes,landing-page,landing-copy,awareness,patients,/,P3
+sangramento ao evacuar,landing-sintomas-condicoes,landing-page,landing-copy,awareness,patients,/,P3
+saúde sexual coloproctologia,landing-sintomas-condicoes,landing-page,landing-copy,awareness,patients,/,P3
+especialista em coloproctologia com formação internacional,marca-dra-ana-luiza,doctor-profile,doctor-name,awareness,patients,/sobre,P3
+quem é dra ana luiza,marca-dra-ana-luiza,doctor-profile,doctor-name,awareness,patients,/sobre,P3
+a cirurgia a laser é sempre melhor que a convencional,plicoma anal,blog-post,faq-question,consideration,patients,/blog/plicoma-anal-cirurgia-laser,P3
+o plicoma pode virar câncer,plicoma anal,blog-post,faq-question,consideration,patients,/blog/plicoma-anal-cirurgia-laser,P3
+preciso obrigatoriamente retirar o plicoma,plicoma anal,blog-post,faq-question,consideration,patients,/blog/plicoma-anal-cirurgia-laser,P3
+quanto tempo dura a recuperação da cirurgia a laser,plicoma anal,blog-post,faq-question,consideration,patients,/blog/plicoma-anal-cirurgia-laser,P3
+com que idade devo começar consultas de rotina,quando procurar coloproctologista,blog-post,faq-question,awareness,patients,/blog/quando-procurar-coloproctologista-curitiba,P3
+especialista cólon reto,quando procurar coloproctologista,blog-post,blog-secondary,awareness,patients,/blog/quando-procurar-coloproctologista-curitiba,P3
+o exame proctológico dói,quando procurar coloproctologista,blog-post,faq-question,awareness,patients,/blog/quando-procurar-coloproctologista-curitiba,P3
+o que devo levar para minha primeira consulta,quando procurar coloproctologista,blog-post,faq-question,awareness,patients,/blog/quando-procurar-coloproctologista-curitiba,P3
+preciso mesmo procurar um coloproctologista se o sangramento for pequeno,quando procurar coloproctologista,blog-post,faq-question,awareness,patients,/blog/quando-procurar-coloproctologista-curitiba,P3
+problemas intestinais,quando procurar coloproctologista,blog-post,blog-secondary,awareness,patients,/blog/quando-procurar-coloproctologista-curitiba,P3
+quando ir ao proctologista,quando procurar coloproctologista,blog-post,blog-secondary,awareness,patients,/blog/quando-procurar-coloproctologista-curitiba,P3
+quando procurar coloproctologista,quando procurar coloproctologista,blog-post,blog-primary,awareness,patients,/blog/quando-procurar-coloproctologista-curitiba,P3
+sintomas coloproctologia,quando procurar coloproctologista,blog-post,blog-secondary,awareness,patients,/blog/quando-procurar-coloproctologista-curitiba,P3
+tenho vergonha de falar sobre meus sintomas o que fazer,quando procurar coloproctologista,blog-post,faq-question,awareness,patients,/blog/quando-procurar-coloproctologista-curitiba,P3
+causas sangue fezes,sangue nas fezes,blog-post,blog-secondary,awareness,patients,/blog/sangue-nas-fezes-quando-procurar-coloproctologista,P3
+hemorroida sangramento,sangue nas fezes,blog-post,blog-secondary,awareness,patients,/blog/sangue-nas-fezes-quando-procurar-coloproctologista,P3
+o sangue pode aparecer mesmo sem dor,sangue nas fezes,blog-post,faq-question,awareness,patients,/blog/sangue-nas-fezes-quando-procurar-coloproctologista,P3
+preciso fazer colonoscopia se tiver sangue nas fezes,sangue nas fezes,blog-post,faq-question,awareness,patients,/blog/sangue-nas-fezes-quando-procurar-coloproctologista,P3
+quando devo procurar um coloproctologista,sangue nas fezes,blog-post,faq-question,awareness,patients,/blog/sangue-nas-fezes-quando-procurar-coloproctologista,P3
+quando preocupar sangramento,sangue nas fezes,blog-post,blog-secondary,awareness,patients,/blog/sangue-nas-fezes-quando-procurar-coloproctologista,P3
+sangramento anal,sangue nas fezes,blog-post,blog-secondary,awareness,patients,/blog/sangue-nas-fezes-quando-procurar-coloproctologista,P3
+sangue nas fezes,sangue nas fezes,blog-post,blog-primary,awareness,patients,/blog/sangue-nas-fezes-quando-procurar-coloproctologista,P3
+sangue nas fezes sempre significa câncer,sangue nas fezes,blog-post,faq-question,awareness,patients,/blog/sangue-nas-fezes-quando-procurar-coloproctologista,P3
+alterações anais podem afetar a vida sexual,saúde sexual,blog-post,faq-question,awareness,patients,/blog/saude-sexual-cuidado-informacao-bem-estar,P3
+dor durante a relação sexual é normal,saúde sexual,blog-post,faq-question,awareness,patients,/blog/saude-sexual-cuidado-informacao-bem-estar,P3
+dor na relação sexual,saúde sexual,blog-post,blog-secondary,awareness,patients,/blog/saude-sexual-cuidado-informacao-bem-estar,P3
+existe tratamento para melhorar o conforto sexual,saúde sexual,blog-post,faq-question,awareness,patients,/blog/saude-sexual-cuidado-informacao-bem-estar,P3
+HPV anal,saúde sexual,blog-post,blog-secondary,awareness,patients,/blog/saude-sexual-cuidado-informacao-bem-estar,P3
+IST anal,saúde sexual,blog-post,blog-secondary,awareness,patients,/blog/saude-sexual-cuidado-informacao-bem-estar,P3
+posso falar sobre práticas sexuais na consulta,saúde sexual,blog-post,faq-question,awareness,patients,/blog/saude-sexual-cuidado-informacao-bem-estar,P3
+saúde anorretal,saúde sexual,blog-post,blog-secondary,awareness,patients,/blog/saude-sexual-cuidado-informacao-bem-estar,P3
+saúde sexual,saúde sexual,blog-post,blog-primary,awareness,patients,/blog/saude-sexual-cuidado-informacao-bem-estar,P3
+dor ao evacuar,sinais de alerta intestinais,blog-post,blog-secondary,awareness,patients,/blog/quando-intestino-da-sinais-de-alerta-coloproctologista-curitiba,P3
+dor ao evacuar é normal,sinais de alerta intestinais,blog-post,faq-question,awareness,patients,/blog/quando-intestino-da-sinais-de-alerta-coloproctologista-curitiba,P3
+mudança no hábito intestinal,sinais de alerta intestinais,blog-post,blog-secondary,awareness,patients,/blog/quando-intestino-da-sinais-de-alerta-coloproctologista-curitiba,P3
+mudança no hábito intestinal pode ser estresse,sinais de alerta intestinais,blog-post,faq-question,awareness,patients,/blog/quando-intestino-da-sinais-de-alerta-coloproctologista-curitiba,P3
+quando é urgente procurar atendimento,sinais de alerta intestinais,blog-post,faq-question,awareness,patients,/blog/quando-intestino-da-sinais-de-alerta-coloproctologista-curitiba,P3
+quando procurar coloproctologista,sinais de alerta intestinais,blog-post,blog-secondary,awareness,patients,/blog/quando-intestino-da-sinais-de-alerta-coloproctologista-curitiba,P3
+sangue nas fezes,sinais de alerta intestinais,blog-post,blog-secondary,awareness,patients,/blog/quando-intestino-da-sinais-de-alerta-coloproctologista-curitiba,P3
+sangue nas fezes sempre é hemorroida,sinais de alerta intestinais,blog-post,faq-question,awareness,patients,/blog/quando-intestino-da-sinais-de-alerta-coloproctologista-curitiba,P3
+sinais de alerta intestinais,sinais de alerta intestinais,blog-post,blog-primary,awareness,patients,/blog/quando-intestino-da-sinais-de-alerta-coloproctologista-curitiba,P3
+a sii pode virar câncer,síndrome do intestino irritável,blog-post,faq-question,awareness,patients,/blog/sindrome-intestino-irritavel-sintomas-diagnostico-tratamento,P3
+a sii tem cura,síndrome do intestino irritável,blog-post,faq-question,awareness,patients,/blog/sindrome-intestino-irritavel-sintomas-diagnostico-tratamento,P3
+ansiedade causa sii,síndrome do intestino irritável,blog-post,faq-question,awareness,patients,/blog/sindrome-intestino-irritavel-sintomas-diagnostico-tratamento,P3
+diagnóstico SII,síndrome do intestino irritável,blog-post,blog-secondary,awareness,patients,/blog/sindrome-intestino-irritavel-sintomas-diagnostico-tratamento,P3
+eixo intestino cérebro,síndrome do intestino irritável,blog-post,blog-secondary,awareness,patients,/blog/sindrome-intestino-irritavel-sintomas-diagnostico-tratamento,P3
+SII sintomas,síndrome do intestino irritável,blog-post,blog-secondary,awareness,patients,/blog/sindrome-intestino-irritavel-sintomas-diagnostico-tratamento,P3
+síndrome do intestino irritável,síndrome do intestino irritável,blog-post,blog-primary,awareness,patients,/blog/sindrome-intestino-irritavel-sintomas-diagnostico-tratamento,P3
+síndrome do intestino irritável é doença grave,síndrome do intestino irritável,blog-post,faq-question,awareness,patients,/blog/sindrome-intestino-irritavel-sintomas-diagnostico-tratamento,P3
+tratamento síndrome do intestino irritável,síndrome do intestino irritável,blog-post,blog-secondary,awareness,patients,/blog/sindrome-intestino-irritavel-sintomas-diagnostico-tratamento,P3
+exames normais significam que está tudo bem,sintomas intestinais persistentes,blog-post,faq-question,consideration,patients,/blog/por-que-meus-sintomas-nunca-melhoram,P3
+hemorroida sempre volta,sintomas intestinais persistentes,blog-post,faq-question,consideration,patients,/blog/por-que-meus-sintomas-nunca-melhoram,P3
+sintomas intestinais persistentes podem ser graves,sintomas intestinais persistentes,blog-post,faq-question,consideration,patients,/blog/por-que-meus-sintomas-nunca-melhoram,P3
+usar laxante todos os dias faz mal,sintomas intestinais persistentes,blog-post,faq-question,consideration,patients,/blog/por-que-meus-sintomas-nunca-melhoram,P3
+consulta com coloproctologista,vergonha de procurar coloproctologista,blog-post,blog-secondary,awareness,patients,/blog/sinto-vergonha-procurar-coloproctologista-isso-e-normal,P3
+dor ao evacuar,vergonha de procurar coloproctologista,blog-post,blog-secondary,awareness,patients,/blog/sinto-vergonha-procurar-coloproctologista-isso-e-normal,P3
+é normal ter vergonha de fazer exame proctológico,vergonha de procurar coloproctologista,blog-post,faq-question,awareness,patients,/blog/sinto-vergonha-procurar-coloproctologista-isso-e-normal,P3
+exame proctológico,vergonha de procurar coloproctologista,blog-post,blog-secondary,awareness,patients,/blog/sinto-vergonha-procurar-coloproctologista-isso-e-normal,P3
+o exame proctológico dói,vergonha de procurar coloproctologista,blog-post,faq-question,awareness,patients,/blog/sinto-vergonha-procurar-coloproctologista-isso-e-normal,P3
+o médico vai me julgar,vergonha de procurar coloproctologista,blog-post,faq-question,awareness,patients,/blog/sinto-vergonha-procurar-coloproctologista-isso-e-normal,P3
+preciso fazer exame já na primeira consulta,vergonha de procurar coloproctologista,blog-post,faq-question,awareness,patients,/blog/sinto-vergonha-procurar-coloproctologista-isso-e-normal,P3
+sangue nas fezes,vergonha de procurar coloproctologista,blog-post,blog-secondary,awareness,patients,/blog/sinto-vergonha-procurar-coloproctologista-isso-e-normal,P3
+vergonha de procurar coloproctologista,vergonha de procurar coloproctologista,blog-post,blog-primary,awareness,patients,/blog/sinto-vergonha-procurar-coloproctologista-isso-e-normal,P3

--- a/docs/seo-keywords-tracking.md
+++ b/docs/seo-keywords-tracking.md
@@ -1,358 +1,79 @@
 # SEO Keywords Tracking Guide
 **Website:** https://www.analuizarocha.com.br/
-**Last Updated:** 2025-11-20
-**Purpose:** 50 core keywords for tracking in GSC, Ahrefs, SEMrush
+**Last Updated:** 2026-03-10
+**Purpose:** Mapa de keywords extraído do conteúdo atual do site para rastreamento contínuo.
 
----
+## Source Of Truth
+- `docs/seo-keywords-tracking.csv`
+- Fontes incluídas no dataset:
+- `content/posts/*.md`
+- `src/app/blog/page.tsx`
+- `src/app/tratamentos/page.tsx`
+- `src/app/tratamentos/**/page.tsx`
+- `src/app/layout.tsx`
+- `src/app/sobre/page.tsx`
+- `src/components/sections/AboutSection.tsx`
+- `src/components/sections/ServicesSection.tsx`
+- `src/components/sections/MissionSection.tsx`
+- `src/components/sections/PhotoSection.tsx`
+- `src/components/sections/TreatmentsSection.tsx`
+- `src/components/sections/LocationsSection.tsx`
+- Copy adicional da landing enviada pelo time
 
-## Quick Copy-Paste: 50 Keywords for SEO Tools
+## Snapshot Atual
+- 365 linhas de keyword + URL
+- 328 keywords únicas
+- Distribuição por prioridade:
+- `P1`: 68
+- `P2`: 118
+- `P3`: 179
+- Distribuição por tipo de conteúdo:
+- `blog-post`: 228
+- `blog-hub`: 8
+- `treatment-page`: 62
+- `treatment-hub`: 7
+- `landing-page`: 40
+- `doctor-profile`: 20
 
-```
-coloproctologista curitiba, proctologista curitiba, dra ana luiza moraes rocha, coloproctologista em curitiba, proctologista em curitiba, médica coloproctologista curitiba, cirurgia colorretal curitiba, coloproctologista batel curitiba, consulta coloproctologista curitiba, agendar coloproctologista curitiba, tratamento hemorroidas curitiba, cirurgia hemorroidas curitiba, fissura anal curitiba, cisto pilonidal curitiba, plicoma anal curitiba, fistula anal curitiba, hpv anal curitiba, sangue nas fezes curitiba, coceira anal curitiba, dor ao evacuar curitiba, cirurgia laser curitiba, ligadura elástica curitiba, THD curitiba, toxina botulínica fissura anal, laser hemorroidas curitiba, laser fístula anal curitiba, cirurgia minimamente invasiva curitiba, anuscopia alta resolução curitiba, hemorroidoplastia laser curitiba, LIFT fístula curitiba, quando procurar coloproctologista, sintomas coloproctologia, o que é plicoma anal, hemorroida precisa cirurgia, sangramento anal é grave, fissura anal tratamento, cisto pilonidal tratamento, constipação intestinal crônica, doenças inflamatórias intestinais, síndrome intestino irritável, melhor coloproctologista curitiba, coloproctologista que aceita convenio curitiba, quanto custa cirurgia hemorroida curitiba, hemorroida externa inflamada tratamento, fissura anal crônica sem cirurgia, cisto pilonidal inflamado o que fazer, coloproctologista feminina curitiba, médica proctologista curitiba, emergência proctológica curitiba, rastreio câncer anal curitiba
-```
+## Novos Grupos Adicionados
+- `landing-page` com `target_url` `/`
+- `doctor-profile` com `target_url` `/sobre`
 
----
+## Quick Copy-Paste: Landing + Marca (P1)
 
-## Keywords by Priority Level
-
-### Priority 1: High Commercial Intent (Track Weekly)
-
-**Local + Specialty:**
-- coloproctologista curitiba
-- proctologista curitiba
-- coloproctologista em curitiba
-- proctologista em curitiba
-- médica coloproctologista curitiba
-- cirurgia colorretal curitiba
-- coloproctologista batel curitiba
-- consulta coloproctologista curitiba
-- agendar coloproctologista curitiba
-
-**Why these matter:** Direct conversion intent. People searching these terms are looking to book an appointment.
-
-**Current Status:**
-- ✅ Homepage optimized for "coloproctologista curitiba"
-- 🎯 Need to add "consulta" and "agendar" variations
-
----
-
-### Priority 2: Condition + Location (Track Weekly)
-
-**Treatment-Focused:**
-- tratamento hemorroidas curitiba
-- cirurgia hemorroidas curitiba
-- fissura anal curitiba
-- cisto pilonidal curitiba
-- plicoma anal curitiba
-- fistula anal curitiba
-- hpv anal curitiba
-- sangue nas fezes curitiba
-- coceira anal curitiba
-- dor ao evacuar curitiba
-
-**Why these matter:** High buying intent. Patients with specific conditions actively seeking treatment.
-
-**Current Status:**
-- ✅ Treatment pages exist for most conditions
-- 🎯 Need blog posts for each to build topical authority
-
----
-
-### Priority 3: Procedure Keywords (Track Biweekly)
-
-**Specific Treatments:**
-- cirurgia laser curitiba
-- ligadura elástica curitiba
-- THD curitiba
-- toxina botulínica fissura anal
-- laser hemorroidas curitiba
-- laser fístula anal curitiba
-- cirurgia minimamente invasiva curitiba
-- anuscopia alta resolução curitiba
-- hemorroidoplastia laser curitiba
-- LIFT fístula curitiba
-
-**Why these matter:** Educated patients researching specific procedures before booking.
-
-**Current Status:**
-- ✅ Treatment pages cover most procedures
-- 🎯 Add procedure-focused blog posts (e.g., "Toxina Botulínica para Fissura: Como Funciona")
-
----
-
-### Priority 4: Informational (Track Monthly)
-
-**Awareness Stage:**
-- quando procurar coloproctologista
-- sintomas coloproctologia
-- o que é plicoma anal
-- hemorroida precisa cirurgia
-- sangramento anal é grave
-- fissura anal tratamento
-- cisto pilonidal tratamento
-- constipação intestinal crônica
-- doenças inflamatórias intestinais
-- síndrome intestino irritável
-
-**Why these matter:** Top of funnel. High volume, lower conversion, but builds authority and captures early-stage patients.
-
-**Current Status:**
-- ✅ Some blog posts published
-- 🎯 Need 30+ more educational posts
-
----
-
-### Priority 5: Long-Tail Conversions (Track Monthly)
-
-**High Intent, Low Volume:**
-- melhor coloproctologista curitiba
-- coloproctologista que aceita convenio curitiba
-- quanto custa cirurgia hemorroida curitiba
-- hemorroida externa inflamada tratamento
-- fissura anal crônica sem cirurgia
-- cisto pilonidal inflamado o que fazer
-- coloproctologista feminina curitiba
-- médica proctologista curitiba
-- emergência proctológica curitiba
-- rastreio câncer anal curitiba
-
-**Why these matter:** Super targeted. Low competition, high conversion rate.
-
-**Current Status:**
-- 🎯 Most missing from content
-- 🎯 Add to blog posts and FAQs
-
----
-
-## Keywords by Page (Current Implementation)
-
-### Homepage (/)
-**Primary Keywords:**
-- coloproctologista curitiba ✅
-- proctologista curitiba ✅
-- cirurgia colorretal curitiba ✅
-
-**Missing Keywords to Add:**
-- consulta coloproctologista curitiba 🎯
-- agendar coloproctologista curitiba 🎯
-- médica coloproctologista curitiba 🎯
-
----
-
-### Blog Listing (/blog)
-**Primary Keywords:**
-- blog coloproctologia ✅
-- artigos coloproctologista curitiba ✅
-- saúde intestinal ✅
-
----
-
-### Treatment Pages
-
-#### /tratamentos/hemorroidas
-**Primary Keywords:**
-- tratamento hemorroidas curitiba ✅
-- cirurgia hemorroidas curitiba ✅
-- ligadura elástica curitiba ✅
-- THD curitiba ✅
-
-#### /tratamentos/cx-fistulas-anorretais
-**Primary Keywords:**
-- cirurgia fistula anal curitiba ✅
-- fistulotomia curitiba ✅
-- LIFT cirurgia curitiba ✅
-
-#### /tratamentos/toxina-botulinica
-**Primary Keywords:**
-- toxina botulínica fissura anal ✅
-- botox fissura anal curitiba ✅
-
-#### /tratamentos/cx-cisto-pilonidal
-**Primary Keywords:**
-- cirurgia cisto pilonidal curitiba ✅
-- cisto pilonidal laser curitiba ✅
-
-#### /tratamentos/hpv-anal
-**Primary Keywords:**
-- hpv anal tratamento curitiba ✅
-- condiloma anal curitiba ✅
-
----
-
-## Missing High-Value Keywords to Add
-
-### 1. Consultation/Booking Keywords (High Priority)
-```
-consulta coloproctologista curitiba
-agendar coloproctologista curitiba
-coloproctologista particular curitiba
-marcar consulta proctologista curitiba
+```txt
+consulta coloproctologista curitiba, agendar consulta coloproctologista curitiba, coloproctologista curitiba batel, proctologista curitiba batel, cirurgia colorretal curitiba, proctologia curitiba, consultório médico coloproctologia curitiba, clínica nassif batel curitiba, cirurgias a laser proctologia curitiba, ligadura elástica para hemorroidas curitiba, toxina botulínica para fissura anal curitiba, rastreio câncer de canal anal curitiba, tratamento de hpv curitiba, dra ana luiza moraes rocha coloproctologista curitiba, dra ana luiza moraes rocha proctologista curitiba, crm-pr 45351, rqe 36221
 ```
 
-**Where to add:**
-- Homepage CTA buttons
-- Header navigation
-- Footer contact section
-- Blog post CTAs
+## Quick Copy-Paste: Doctor Profile Keywords
 
----
-
-### 2. Insurance/Payment Keywords (Medium Priority)
-```
-coloproctologista que aceita unimed curitiba
-coloproctologista convenio curitiba
-valor consulta coloproctologista curitiba
-quanto custa cirurgia hemorroida curitiba
+```txt
+dra ana luiza moraes rocha, dra ana luiza m rocha, ana luiza moraes rocha, ana luiza rocha coloproctologista, proctologista dra ana luiza curitiba, médica coloproctologista curitiba, crm pr 45351, rqe 36221 coloproctologia, crm pr 45351 rqe 36221, puc-pr medicina, hospital santa casa de curitiba cirurgia geral, hospital universitário evangélico mackenzie coloproctologia, mestranda ufpr clínica cirúrgica, international anal neoplasia society, membro ians coloproctologia, fellow cirurgia colorretal barcelona, hospital clinic barcelona cirurgia colorretal, anuscopia de alta resolução curitiba
 ```
 
-**Where to add:**
-- FAQ section on treatment pages
-- Dedicated "Convênios" page
-- Blog post about costs/insurance
+## Como Rastrear O Que Os Usuários Estão Trazendo (Queries Reais)
+1. Abrir Google Search Console em `Performance > Search results`.
+2. Aplicar filtro de página `Page: exactly https://www.analuizarocha.com.br/` para landing.
+3. Aplicar filtro de página `Page: exactly https://www.analuizarocha.com.br/sobre` para perfil médico.
+4. Ir na aba `Queries` e exportar últimos 28 dias e 3 meses.
+5. Cruzar com `docs/seo-keywords-tracking.csv` usando `keyword` e `target_url`.
+6. Priorizar queries com alta impressão e CTR baixo para otimização de título/meta.
 
----
+## Segmentos Recomendados De Query (Regex)
+- Marca médica: `ana luiza|dra ana|moraes rocha|crm|rqe`
+- Local/intenção de consulta: `curitiba|batel|consulta|agendar|proctologista|coloproctologista`
+- Condição/sintoma: `hemorroid|fissura|fístula|coceira|hpv|cisto|constipa|diarreia|intestino irritável|crohn|retocolite`
 
-### 3. Demographic Keywords (Medium Priority)
-```
-coloproctologista feminina curitiba
-médica proctologista curitiba
-coloproctologista mulher curitiba
-```
+## Colunas Do CSV
+- `keyword`: termo rastreado
+- `cluster`: tema central
+- `content_type`: `blog-post`, `blog-hub`, `treatment-page`, `treatment-hub`, `landing-page`, `doctor-profile`
+- `source`: origem do termo
+- `intent`: `awareness`, `consideration`, `decision`
+- `audience`: público-alvo
+- `target_url`: URL recomendada para ranquear
+- `priority`: `P1`, `P2`, `P3`
 
-**Where to add:**
-- About page H2/H3 headings
-- Homepage "Sobre a Dra. Ana Luiza" section
-- Meta descriptions
-
----
-
-### 4. Exam/Procedure Detail Keywords (Low Priority)
-```
-anuscopia de alta resolução curitiba
-exame proctológico curitiba
-retossigmoidoscopia curitiba
-colonoscopia curitiba
-```
-
-**Where to add:**
-- Blog posts about each exam type
-- Treatment pages (diagnostic section)
-
----
-
-## Keyword Tracking Setup
-
-### Google Search Console
-1. Go to Performance report
-2. Filter by query
-3. Create custom reports for each priority group
-4. Export data monthly
-
-**Metrics to Track:**
-- Average position
-- Total clicks
-- Total impressions
-- CTR
-
-**Goal:**
-- 80% of Priority 1-2 keywords in top 20 within 6 months
-- 50% of Priority 1 keywords in top 10 within 12 months
-
----
-
-### Ahrefs/SEMrush Setup
-1. Add website to project
-2. Create keyword lists for each priority group
-3. Set up rank tracking for all 50 keywords
-4. Enable email alerts for ranking changes (±3 positions)
-
-**Refresh frequency:**
-- Priority 1-2: Daily
-- Priority 3-4: Weekly
-- Priority 5: Monthly
-
----
-
-## Monthly KPI Targets
-
-### Month 1-3 (Foundation)
-- **Rankings:** 20 keywords in top 50
-- **Traffic:** 500+ organic sessions/month
-- **Conversions:** 10+ form submissions or WhatsApp clicks
-
-### Month 4-6 (Growth)
-- **Rankings:** 30 keywords in top 30, 10 in top 10
-- **Traffic:** 1,000+ organic sessions/month
-- **Conversions:** 25+ form submissions or WhatsApp clicks
-
-### Month 7-12 (Dominance)
-- **Rankings:** 40 keywords in top 20, 20 in top 10, 5 in top 3
-- **Traffic:** 2,500+ organic sessions/month
-- **Conversions:** 50+ form submissions or WhatsApp clicks
-
----
-
-## Competitor Benchmark Keywords
-
-Track these to monitor competitive positioning:
-
-```
-coloproctologista em curitiba avaliação
-melhor proctologista de curitiba
-coloproctologista curitiba preço
-cirurgia hemorroidas curitiba preço
-coloproctologista 24 horas curitiba
-pronto atendimento proctológico curitiba
-```
-
-**Competitive Analysis (Quarterly):**
-1. Identify top 3 competitors in GSC
-2. Compare keyword overlap
-3. Find gaps where they rank and you don't
-4. Create content to fill gaps
-
----
-
-## How to Use This Document
-
-### Weekly Review:
-- Check Priority 1-2 keyword rankings
-- Identify any major position drops (>5 positions)
-- Review top-performing pages and optimize similar content
-
-### Monthly Review:
-- Export GSC data for all 50 keywords
-- Track progress toward KPI targets
-- Update content plan based on ranking gaps
-- Rewrite meta descriptions for low-CTR pages
-
-### Quarterly Review:
-- Full competitor analysis
-- Refresh keyword list (add new opportunities)
-- Audit content performance (update underperforming posts)
-- Review backlink profile
-
----
-
-## Quick Reference: Keyword Integration Checklist
-
-For every new page/post:
-
-- [ ] Primary keyword in H1
-- [ ] Primary keyword in first 100 words
-- [ ] Primary keyword in URL slug
-- [ ] Primary keyword in meta title
-- [ ] Primary keyword + "Curitiba" in meta description
-- [ ] 2-3 secondary keywords in H2/H3 headings
-- [ ] LSI keywords naturally throughout content
-- [ ] Location modifier in at least 3 places
-- [ ] Internal links with keyword-rich anchor text
-
----
-
-**Last Updated:** 2025-11-20
-**Next Review:** 2026-02-20
-
-**Related Documents:**
-- `seo-strategy-implementation.md` - Overall SEO strategy and execution plan
-- `blog-content-roadmap.md` - Detailed blog post outlines (if needed for reference)
+## Observações
+- Não é possível identificar query por usuário individual no GSC; os dados são agregados por consulta/página/período.
+- O dataset foi expandido para incluir marca pessoal, credenciais profissionais e sinais da landing page.

--- a/docs/serp-keywords-tracking.csv
+++ b/docs/serp-keywords-tracking.csv
@@ -1,0 +1,329 @@
+Keywords,Your actual rank (1-30+),Your URL that's ranking,Your page title in search results,Top ranking domain (competitor),Top result's title,Total search results,Timestamp
+agendar consulta coloproctologista curitiba,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+ana luiza moraes rocha,,https://www.analuizarocha.com.br/sobre,Sobre a Dra. Ana Luiza M. Rocha | Especialista em Coloproctologia,,,,3/10/2026
+ana luiza rocha coloproctologista,,https://www.analuizarocha.com.br/sobre,Sobre a Dra. Ana Luiza M. Rocha | Especialista em Coloproctologia,,,,3/10/2026
+anuscopia alta resolução curitiba,,https://www.analuizarocha.com.br/tratamentos/rastreio-cancer-anal,Rastreio de Câncer Anal e HPV,,,,3/10/2026
+botox fissura anal curitiba,,https://www.analuizarocha.com.br/tratamentos/toxina-botulinica,Toxina Botulínica para Fissura Anal,,,,3/10/2026
+cirurgia cisto pilonidal curitiba,,https://www.analuizarocha.com.br/tratamentos/cx-cisto-pilonidal,Cisto Pilonidal: Cirurgia e Recuperação,,,,3/10/2026
+cirurgia coccix curitiba,,https://www.analuizarocha.com.br/tratamentos/cx-cisto-pilonidal,Cisto Pilonidal: Cirurgia e Recuperação,,,,3/10/2026
+cirurgia colorretal curitiba,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+cirurgia fistula anal curitiba,,https://www.analuizarocha.com.br/tratamentos/cx-fistulas-anorretais,Fístula Anal: Cirurgia Especializada,,,,3/10/2026
+cirurgia hemorroidas curitiba,,https://www.analuizarocha.com.br/tratamentos,Tratamentos de Coloproctologia em Curitiba,,,,3/10/2026
+cirurgia hemorroidas laser curitiba,,https://www.analuizarocha.com.br/tratamentos/hemorroidas,Hemorroidas: Tratamento em Curitiba,,,,3/10/2026
+cirurgia laser curitiba,,https://www.analuizarocha.com.br/tratamentos,Tratamentos de Coloproctologia em Curitiba,,,,3/10/2026
+cirurgia laser hemorroidas curitiba,,https://www.analuizarocha.com.br/tratamentos/cx-laser,Cirurgia a Laser Proctológica,,,,3/10/2026
+cirurgia minimamente invasiva curitiba,,https://www.analuizarocha.com.br/tratamentos/cx-laser,Cirurgia a Laser Proctológica,,,,3/10/2026
+cirurgias a laser proctologia curitiba,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+cisto pilonidal curitiba,,https://www.analuizarocha.com.br/tratamentos,Tratamentos de Coloproctologia em Curitiba,,,,3/10/2026
+cisto pilonidal laser curitiba,,https://www.analuizarocha.com.br/tratamentos/cx-cisto-pilonidal,Cisto Pilonidal: Cirurgia e Recuperação,,,,3/10/2026
+cisto sacrococcigeo curitiba,,https://www.analuizarocha.com.br/tratamentos/cx-cisto-pilonidal,Cisto Pilonidal: Cirurgia e Recuperação,,,,3/10/2026
+citologia anal curitiba,,https://www.analuizarocha.com.br/tratamentos/rastreio-cancer-anal,Rastreio de Câncer Anal e HPV,,,,3/10/2026
+clínica nassif batel curitiba,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+coloproctologia curitiba,,https://www.analuizarocha.com.br/tratamentos,Tratamentos de Coloproctologia em Curitiba,,,,3/10/2026
+coloproctologista curitiba batel,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+coloproctologista SII curitiba,,https://www.analuizarocha.com.br/tratamentos/sindrome-intestino-irritavel,Síndrome do Intestino Irritável (SII),,,,3/10/2026
+condiloma anal curitiba,,https://www.analuizarocha.com.br/tratamentos/hpv-anal,HPV Anal: Condilomas e Tratamento,,,,3/10/2026
+consulta coloproctologista curitiba,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+consultório médico coloproctologia curitiba,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+crm pr 45351,,https://www.analuizarocha.com.br/sobre,Sobre a Dra. Ana Luiza M. Rocha | Especialista em Coloproctologia,,,,3/10/2026
+crm pr 45351 rqe 36221,,https://www.analuizarocha.com.br/sobre,Sobre a Dra. Ana Luiza M. Rocha | Especialista em Coloproctologia,,,,3/10/2026
+crm-pr 45351,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+DII curitiba,,https://www.analuizarocha.com.br/tratamentos/doencas-inflamatorias-intestinais,DII: Crohn e Retocolite,,,,3/10/2026
+doença de crohn curitiba,,https://www.analuizarocha.com.br/tratamentos/doencas-inflamatorias-intestinais,DII: Crohn e Retocolite,,,,3/10/2026
+doenças inflamatórias intestinais curitiba,,https://www.analuizarocha.com.br/tratamentos/doencas-inflamatorias-intestinais,DII: Crohn e Retocolite,,,,3/10/2026
+dor anal cronica curitiba,,https://www.analuizarocha.com.br/tratamentos/toxina-botulinica,Toxina Botulínica para Fissura Anal,,,,3/10/2026
+dra ana luiza m rocha,,https://www.analuizarocha.com.br/sobre,Sobre a Dra. Ana Luiza M. Rocha | Especialista em Coloproctologia,,,,3/10/2026
+dra ana luiza moraes rocha,,https://www.analuizarocha.com.br/sobre,Sobre a Dra. Ana Luiza M. Rocha | Especialista em Coloproctologia,,,,3/10/2026
+dra ana luiza moraes rocha coloproctologista curitiba,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+dra ana luiza moraes rocha proctologista curitiba,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+esfíncter anal curitiba,,https://www.analuizarocha.com.br/tratamentos/toxina-botulinica,Toxina Botulínica para Fissura Anal,,,,3/10/2026
+fissura anal laser curitiba,,https://www.analuizarocha.com.br/tratamentos/cx-laser,Cirurgia a Laser Proctológica,,,,3/10/2026
+fistulotomia curitiba,,https://www.analuizarocha.com.br/tratamentos/cx-fistulas-anorretais,Fístula Anal: Cirurgia Especializada,,,,3/10/2026
+hemorroidectomia curitiba,,https://www.analuizarocha.com.br/tratamentos/hemorroidas,Hemorroidas: Tratamento em Curitiba,,,,3/10/2026
+HPV anal curitiba,,https://www.analuizarocha.com.br/tratamentos,Tratamentos de Coloproctologia em Curitiba,,,,3/10/2026
+LIFT cirurgia curitiba,,https://www.analuizarocha.com.br/tratamentos/cx-fistulas-anorretais,Fístula Anal: Cirurgia Especializada,,,,3/10/2026
+ligadura elástica curitiba,,https://www.analuizarocha.com.br/tratamentos/hemorroidas,Hemorroidas: Tratamento em Curitiba,,,,3/10/2026
+ligadura elástica para hemorroidas curitiba,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+médica coloproctologista curitiba,,https://www.analuizarocha.com.br/sobre,Sobre a Dra. Ana Luiza M. Rocha | Especialista em Coloproctologia,,,,3/10/2026
+proctologia curitiba,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+proctologista curitiba,,https://www.analuizarocha.com.br/tratamentos,Tratamentos de Coloproctologia em Curitiba,,,,3/10/2026
+proctologista curitiba batel,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+proctologista dra ana luiza curitiba,,https://www.analuizarocha.com.br/sobre,Sobre a Dra. Ana Luiza M. Rocha | Especialista em Coloproctologia,,,,3/10/2026
+proctologista laser curitiba,,https://www.analuizarocha.com.br/tratamentos/cx-laser,Cirurgia a Laser Proctológica,,,,3/10/2026
+rastreio cancer anal curitiba,,https://www.analuizarocha.com.br/tratamentos/rastreio-cancer-anal,Rastreio de Câncer Anal e HPV,,,,3/10/2026
+rastreio câncer de canal anal curitiba,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+retocolite ulcerativa curitiba,,https://www.analuizarocha.com.br/tratamentos/doencas-inflamatorias-intestinais,DII: Crohn e Retocolite,,,,3/10/2026
+rqe 36221,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+rqe 36221 coloproctologia,,https://www.analuizarocha.com.br/sobre,Sobre a Dra. Ana Luiza M. Rocha | Especialista em Coloproctologia,,,,3/10/2026
+seton fistula anal curitiba,,https://www.analuizarocha.com.br/tratamentos/cx-fistulas-anorretais,Fístula Anal: Cirurgia Especializada,,,,3/10/2026
+SII curitiba,,https://www.analuizarocha.com.br/tratamentos/sindrome-intestino-irritavel,Síndrome do Intestino Irritável (SII),,,,3/10/2026
+sindrome intestino irritavel curitiba,,https://www.analuizarocha.com.br/tratamentos/sindrome-intestino-irritavel,Síndrome do Intestino Irritável (SII),,,,3/10/2026
+THD curitiba,,https://www.analuizarocha.com.br/tratamentos/hemorroidas,Hemorroidas: Tratamento em Curitiba,,,,3/10/2026
+toxina botulinica anal curitiba,,https://www.analuizarocha.com.br/tratamentos/toxina-botulinica,Toxina Botulínica para Fissura Anal,,,,3/10/2026
+toxina botulínica para fissura anal curitiba,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+tratamento crohn curitiba,,https://www.analuizarocha.com.br/tratamentos/doencas-inflamatorias-intestinais,DII: Crohn e Retocolite,,,,3/10/2026
+tratamento de hpv curitiba,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+tratamento fissura anal,,https://www.analuizarocha.com.br/tratamentos,Tratamentos de Coloproctologia em Curitiba,,,,3/10/2026
+tratamento hemorroidas curitiba,,https://www.analuizarocha.com.br/tratamentos/hemorroidas,Hemorroidas: Tratamento em Curitiba,,,,3/10/2026
+tratamento HPV anal curitiba,,https://www.analuizarocha.com.br/tratamentos/hpv-anal,HPV Anal: Condilomas e Tratamento,,,,3/10/2026
+verrugas anais curitiba,,https://www.analuizarocha.com.br/tratamentos/hpv-anal,HPV Anal: Condilomas e Tratamento,,,,3/10/2026
+abscesso sacrococcígeo,,https://www.analuizarocha.com.br/blog/cisto-pilonidal-cirurgia-laser-quando-operar,"Cisto pilonidal: o que é, por que acontece e quando é a melhor hora de operar",,,,3/10/2026
+acompanhamento coloproctológico,,https://www.analuizarocha.com.br/blog/o-que-muda-acompanhamento-especializado-coloproctologista-curitiba,O que muda quando você tem acompanhamento especializado?,,,,3/10/2026
+acompanhamento DII,,https://www.analuizarocha.com.br/blog/doencas-inflamatorias-intestinais-acompanhamento,Doenças inflamatórias intestinais (DII): acompanhamento especializado,,,,3/10/2026
+acompanhamento especializado,,https://www.analuizarocha.com.br/blog/o-que-muda-acompanhamento-especializado-coloproctologista-curitiba,O que muda quando você tem acompanhamento especializado?,,,,3/10/2026
+anuscopia de alta resolução curitiba,,https://www.analuizarocha.com.br/sobre,Sobre a Dra. Ana Luiza M. Rocha | Especialista em Coloproctologia,,,,3/10/2026
+artigos coloproctologista curitiba,,https://www.analuizarocha.com.br/blog,Blog de Coloproctologia e Saúde Intestinal,,,,3/10/2026
+atendimento humanizado coloproctologia curitiba,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+cirurgia a laser cisto pilonidal,,https://www.analuizarocha.com.br/blog/cisto-pilonidal-cirurgia-laser-quando-operar,"Cisto pilonidal: o que é, por que acontece e quando é a melhor hora de operar",,,,3/10/2026
+cirurgia a laser plicoma,,https://www.analuizarocha.com.br/blog/plicoma-anal-cirurgia-laser,Plicoma anal: o que é e como a cirurgia a laser pode auxiliar na recuperação,,,,3/10/2026
+cirurgia a laser proctológica,,https://www.analuizarocha.com.br/tratamentos/cx-laser,Cirurgia a Laser Proctológica,,,,3/10/2026
+cirurgia hemorroida laser,,https://www.analuizarocha.com.br/blog/hemorroida-sempre-cirurgica-tratamento,Hemorroida é sempre cirúrgica? Entenda quando operar e opções de tratamento,,,,3/10/2026
+cisto pilonidal,,https://www.analuizarocha.com.br/tratamentos/cx-cisto-pilonidal,Cisto Pilonidal: Cirurgia e Recuperação,,,,3/10/2026
+coceira anal curitiba,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+colonoscopia curitiba mercês,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+coloproctologia laser,,https://www.analuizarocha.com.br/tratamentos/cx-laser,Cirurgia a Laser Proctológica,,,,3/10/2026
+coloproctologista Curitiba,,https://www.analuizarocha.com.br/blog/tratamento-fistulas-anorretais,Tratamento de fístulas anorretais,,,,3/10/2026
+coloproctologista DII,,https://www.analuizarocha.com.br/tratamentos/doencas-inflamatorias-intestinais,DII: Crohn e Retocolite,,,,3/10/2026
+coloproctologista em Curitiba,,https://www.analuizarocha.com.br/blog/por-que-meus-sintomas-nunca-melhoram,Por que meus sintomas nunca melhoram?,,,,3/10/2026
+constipação intestinal curitiba,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+diarreia crônica,,https://www.analuizarocha.com.br/blog/diarreia-cronica-tratamento,"Diarreia crônica: causas, diagnóstico e tratamentos",,,,3/10/2026
+diarreia crônica curitiba,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+diarreia nervosa,,https://www.analuizarocha.com.br/blog/diarreia-cronica-tratamento,"Diarreia crônica: causas, diagnóstico e tratamentos",,,,3/10/2026
+dii,,https://www.analuizarocha.com.br/tratamentos/doencas-inflamatorias-intestinais,DII: Crohn e Retocolite,,,,3/10/2026
+disturbio funcional intestinal,,https://www.analuizarocha.com.br/tratamentos/sindrome-intestino-irritavel,Síndrome do Intestino Irritável (SII),,,,3/10/2026
+distúrbios do assoalho pélvico curitiba,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+Doença de Crohn,,https://www.analuizarocha.com.br/blog/doencas-inflamatorias-intestinais-acompanhamento,Doenças inflamatórias intestinais (DII): acompanhamento especializado,,,,3/10/2026
+doenças inflamatórias intestinais,,https://www.analuizarocha.com.br/blog/doencas-inflamatorias-intestinais-acompanhamento,Doenças inflamatórias intestinais (DII): acompanhamento especializado,,,,3/10/2026
+dor abdominal cronica,,https://www.analuizarocha.com.br/tratamentos/sindrome-intestino-irritavel,Síndrome do Intestino Irritável (SII),,,,3/10/2026
+dor anal curitiba,,https://www.analuizarocha.com.br/blog/fissura-anal-tratamento,"Fissura anal: sintomas, tratamentos e como a coloproctologia pode ajudar",,,,3/10/2026
+dor ao evacuar,,https://www.analuizarocha.com.br/blog/fissura-anal-tratamento,"Fissura anal: sintomas, tratamentos e como a coloproctologia pode ajudar",,,,3/10/2026
+drenagem x cirurgia definitiva,,https://www.analuizarocha.com.br/blog/cisto-pilonidal-cirurgia-laser-quando-operar,"Cisto pilonidal: o que é, por que acontece e quando é a melhor hora de operar",,,,3/10/2026
+eletrocauterização HPV,,https://www.analuizarocha.com.br/tratamentos/hpv-anal,HPV Anal: Condilomas e Tratamento,,,,3/10/2026
+escleroterapia hemorroidas,,https://www.analuizarocha.com.br/tratamentos/hemorroidas,Hemorroidas: Tratamento em Curitiba,,,,3/10/2026
+esfincterotomia,,https://www.analuizarocha.com.br/blog/fissura-anal-tratamento,"Fissura anal: sintomas, tratamentos e como a coloproctologia pode ajudar",,,,3/10/2026
+exames diarreia,,https://www.analuizarocha.com.br/blog/diarreia-cronica-tratamento,"Diarreia crônica: causas, diagnóstico e tratamentos",,,,3/10/2026
+exames normais e sintomas,,https://www.analuizarocha.com.br/blog/por-que-meus-sintomas-nunca-melhoram,Por que meus sintomas nunca melhoram?,,,,3/10/2026
+fellow cirurgia colorretal barcelona,,https://www.analuizarocha.com.br/sobre,Sobre a Dra. Ana Luiza M. Rocha | Especialista em Coloproctologia,,,,3/10/2026
+fissura anal,,https://www.analuizarocha.com.br/blog/fissura-anal-tratamento,"Fissura anal: sintomas, tratamentos e como a coloproctologia pode ajudar",,,,3/10/2026
+fissura anal curitiba,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+fístula anal,,https://www.analuizarocha.com.br/tratamentos/cx-fistulas-anorretais,Fístula Anal: Cirurgia Especializada,,,,3/10/2026
+fístula anal curitiba,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+fístulas anorretais,,https://www.analuizarocha.com.br/blog/tratamento-fistulas-anorretais,Tratamento de fístulas anorretais,,,,3/10/2026
+hemorroida é cirúrgica,,https://www.analuizarocha.com.br/blog/hemorroida-sempre-cirurgica-tratamento,Hemorroida é sempre cirúrgica? Entenda quando operar e opções de tratamento,,,,3/10/2026
+hemorroida interna externa,,https://www.analuizarocha.com.br/blog/hemorroida-sempre-cirurgica-tratamento,Hemorroida é sempre cirúrgica? Entenda quando operar e opções de tratamento,,,,3/10/2026
+hemorroidas,,https://www.analuizarocha.com.br/tratamentos/hemorroidas,Hemorroidas: Tratamento em Curitiba,,,,3/10/2026
+hemorroidas curitiba,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+hemorroidas recorrentes,,https://www.analuizarocha.com.br/blog/por-que-meus-sintomas-nunca-melhoram,Por que meus sintomas nunca melhoram?,,,,3/10/2026
+higiene anal difícil,,https://www.analuizarocha.com.br/blog/plicoma-anal-cirurgia-laser,Plicoma anal: o que é e como a cirurgia a laser pode auxiliar na recuperação,,,,3/10/2026
+hospital clinic barcelona cirurgia colorretal,,https://www.analuizarocha.com.br/sobre,Sobre a Dra. Ana Luiza M. Rocha | Especialista em Coloproctologia,,,,3/10/2026
+hospital santa casa de curitiba cirurgia geral,,https://www.analuizarocha.com.br/sobre,Sobre a Dra. Ana Luiza M. Rocha | Especialista em Coloproctologia,,,,3/10/2026
+hospital universitário evangélico mackenzie coloproctologia,,https://www.analuizarocha.com.br/sobre,Sobre a Dra. Ana Luiza M. Rocha | Especialista em Coloproctologia,,,,3/10/2026
+hpv anal,,https://www.analuizarocha.com.br/tratamentos/hpv-anal,HPV Anal: Condilomas e Tratamento,,,,3/10/2026
+HPV canal anal,,https://www.analuizarocha.com.br/tratamentos/rastreio-cancer-anal,Rastreio de Câncer Anal e HPV,,,,3/10/2026
+IANS coloproctologia,,https://www.analuizarocha.com.br/tratamentos/rastreio-cancer-anal,Rastreio de Câncer Anal e HPV,,,,3/10/2026
+imiquimode condiloma,,https://www.analuizarocha.com.br/tratamentos/hpv-anal,HPV Anal: Condilomas e Tratamento,,,,3/10/2026
+international anal neoplasia society,,https://www.analuizarocha.com.br/sobre,Sobre a Dra. Ana Luiza M. Rocha | Especialista em Coloproctologia,,,,3/10/2026
+intestino desregulado,,https://www.analuizarocha.com.br/blog/por-que-meus-sintomas-nunca-melhoram,Por que meus sintomas nunca melhoram?,,,,3/10/2026
+intestino irritavel tratamento,,https://www.analuizarocha.com.br/tratamentos/sindrome-intestino-irritavel,Síndrome do Intestino Irritável (SII),,,,3/10/2026
+intestino solto,,https://www.analuizarocha.com.br/blog/diarreia-cronica-tratamento,"Diarreia crônica: causas, diagnóstico e tratamentos",,,,3/10/2026
+laser fistula anal,,https://www.analuizarocha.com.br/tratamentos/cx-fistulas-anorretais,Fístula Anal: Cirurgia Especializada,,,,3/10/2026
+laser HPV anal,,https://www.analuizarocha.com.br/tratamentos/hpv-anal,HPV Anal: Condilomas e Tratamento,,,,3/10/2026
+laser pilonidal,,https://www.analuizarocha.com.br/tratamentos/cx-cisto-pilonidal,Cisto Pilonidal: Cirurgia e Recuperação,,,,3/10/2026
+laxantes irritativos,,https://www.analuizarocha.com.br/blog/por-que-meus-sintomas-nunca-melhoram,Por que meus sintomas nunca melhoram?,,,,3/10/2026
+ligadura elástica hemorroida,,https://www.analuizarocha.com.br/blog/hemorroida-sempre-cirurgica-tratamento,Hemorroida é sempre cirúrgica? Entenda quando operar e opções de tratamento,,,,3/10/2026
+médico intestino Curitiba,,https://www.analuizarocha.com.br/blog/quando-procurar-coloproctologista-curitiba,Quando procurar um coloproctologista: guia completo,,,,3/10/2026
+membro ians coloproctologia,,https://www.analuizarocha.com.br/sobre,Sobre a Dra. Ana Luiza M. Rocha | Especialista em Coloproctologia,,,,3/10/2026
+mestranda ufpr clínica cirúrgica,,https://www.analuizarocha.com.br/sobre,Sobre a Dra. Ana Luiza M. Rocha | Especialista em Coloproctologia,,,,3/10/2026
+plicoma anal,,https://www.analuizarocha.com.br/blog/plicoma-anal-cirurgia-laser,Plicoma anal: o que é e como a cirurgia a laser pode auxiliar na recuperação,,,,3/10/2026
+prevenção cancer anal,,https://www.analuizarocha.com.br/tratamentos/rastreio-cancer-anal,Rastreio de Câncer Anal e HPV,,,,3/10/2026
+prevenção de recorrências intestinais,,https://www.analuizarocha.com.br/blog/o-que-muda-acompanhamento-especializado-coloproctologista-curitiba,O que muda quando você tem acompanhamento especializado?,,,,3/10/2026
+procedimento minimamente invasivo,,https://www.analuizarocha.com.br/tratamentos/toxina-botulinica,Toxina Botulínica para Fissura Anal,,,,3/10/2026
+prurido anal curitiba,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+puc-pr medicina,,https://www.analuizarocha.com.br/sobre,Sobre a Dra. Ana Luiza M. Rocha | Especialista em Coloproctologia,,,,3/10/2026
+rastreio de câncer anal e hpv,,https://www.analuizarocha.com.br/tratamentos/rastreio-cancer-anal,Rastreio de Câncer Anal e HPV,,,,3/10/2026
+recidiva cisto pilonidal,,https://www.analuizarocha.com.br/blog/cisto-pilonidal-cirurgia-laser-quando-operar,"Cisto pilonidal: o que é, por que acontece e quando é a melhor hora de operar",,,,3/10/2026
+recuperação plicoma,,https://www.analuizarocha.com.br/blog/plicoma-anal-cirurgia-laser,Plicoma anal: o que é e como a cirurgia a laser pode auxiliar na recuperação,,,,3/10/2026
+retalho mucoso fistula,,https://www.analuizarocha.com.br/tratamentos/cx-fistulas-anorretais,Fístula Anal: Cirurgia Especializada,,,,3/10/2026
+Retocolite Ulcerativa,,https://www.analuizarocha.com.br/blog/doencas-inflamatorias-intestinais-acompanhamento,Doenças inflamatórias intestinais (DII): acompanhamento especializado,,,,3/10/2026
+sangramento anal curitiba,,https://www.analuizarocha.com.br/blog/fissura-anal-tratamento,"Fissura anal: sintomas, tratamentos e como a coloproctologia pode ajudar",,,,3/10/2026
+saúde intestinal a longo prazo,,https://www.analuizarocha.com.br/blog/o-que-muda-acompanhamento-especializado-coloproctologista-curitiba,O que muda quando você tem acompanhamento especializado?,,,,3/10/2026
+seton,,https://www.analuizarocha.com.br/blog/tratamento-fistulas-anorretais,Tratamento de fístulas anorretais,,,,3/10/2026
+síndrome do intestino irritável (sii),,https://www.analuizarocha.com.br/tratamentos/sindrome-intestino-irritavel,Síndrome do Intestino Irritável (SII),,,,3/10/2026
+síndrome do intestino irritável curitiba,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+síndrome intestino irritável,,https://www.analuizarocha.com.br/blog/diarreia-cronica-tratamento,"Diarreia crônica: causas, diagnóstico e tratamentos",,,,3/10/2026
+sintomas intestinais persistentes,,https://www.analuizarocha.com.br/blog/por-que-meus-sintomas-nunca-melhoram,Por que meus sintomas nunca melhoram?,,,,3/10/2026
+sobras de pele anal,,https://www.analuizarocha.com.br/blog/plicoma-anal-cirurgia-laser,Plicoma anal: o que é e como a cirurgia a laser pode auxiliar na recuperação,,,,3/10/2026
+specta endoscopia digestiva curitiba,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+técnica LIFT,,https://www.analuizarocha.com.br/blog/tratamento-fistulas-anorretais,Tratamento de fístulas anorretais,,,,3/10/2026
+toxina botulínica fissura,,https://www.analuizarocha.com.br/blog/fissura-anal-tratamento,"Fissura anal: sintomas, tratamentos e como a coloproctologia pode ajudar",,,,3/10/2026
+toxina botulínica para fissura anal,,https://www.analuizarocha.com.br/tratamentos/toxina-botulinica,Toxina Botulínica para Fissura Anal,,,,3/10/2026
+tratamento cisto pilonidal,,https://www.analuizarocha.com.br/tratamentos/cx-cisto-pilonidal,Cisto Pilonidal: Cirurgia e Recuperação,,,,3/10/2026
+tratamento DII,,https://www.analuizarocha.com.br/blog/doencas-inflamatorias-intestinais-acompanhamento,Doenças inflamatórias intestinais (DII): acompanhamento especializado,,,,3/10/2026
+tratamento fístula anal,,https://www.analuizarocha.com.br/blog/tratamento-fistulas-anorretais,Tratamento de fístulas anorretais,,,,3/10/2026
+tratamento hemorroida,,https://www.analuizarocha.com.br/blog/hemorroida-sempre-cirurgica-tratamento,Hemorroida é sempre cirúrgica? Entenda quando operar e opções de tratamento,,,,3/10/2026
+tratamento intestinal individualizado,,https://www.analuizarocha.com.br/blog/o-que-muda-acompanhamento-especializado-coloproctologista-curitiba,O que muda quando você tem acompanhamento especializado?,,,,3/10/2026
+tratamentos minimamente invasivos coloproctologia,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+a cirurgia a laser dói,,https://www.analuizarocha.com.br/blog/cisto-pilonidal-cirurgia-laser-quando-operar,"Cisto pilonidal: o que é, por que acontece e quando é a melhor hora de operar",,,,3/10/2026
+a cirurgia a laser é sempre melhor que a convencional,,https://www.analuizarocha.com.br/blog/plicoma-anal-cirurgia-laser,Plicoma anal: o que é e como a cirurgia a laser pode auxiliar na recuperação,,,,3/10/2026
+a cirurgia de fissura anal causa incontinência,,https://www.analuizarocha.com.br/blog/fissura-anal-tratamento,"Fissura anal: sintomas, tratamentos e como a coloproctologia pode ajudar",,,,3/10/2026
+a colonoscopia é segura,,https://www.analuizarocha.com.br/blog/cancer-colorretal-rastreio-prevencao-diagnostico-precoce,"Câncer colorretal: rastreio, prevenção e a importância do diagnóstico precoce",,,,3/10/2026
+a fissura anal pode cicatrizar sozinha,,https://www.analuizarocha.com.br/blog/fissura-anal-tratamento,"Fissura anal: sintomas, tratamentos e como a coloproctologia pode ajudar",,,,3/10/2026
+a ligadura elástica dói,,https://www.analuizarocha.com.br/blog/hemorroida-sempre-cirurgica-tratamento,Hemorroida é sempre cirúrgica? Entenda quando operar e opções de tratamento,,,,3/10/2026
+a prisão de ventre pode causar hemorroidas,,https://www.analuizarocha.com.br/blog/constipacao-intestinal-cronica-causas-tratamento,"Constipação intestinal crônica: causas, tratamentos e quando procurar especialista",,,,3/10/2026
+a sii pode virar câncer,,https://www.analuizarocha.com.br/blog/sindrome-intestino-irritavel-sintomas-diagnostico-tratamento,"Síndrome do Intestino Irritável (SII): sintomas, diagnóstico e tratamento personalizado",,,,3/10/2026
+a sii tem cura,,https://www.analuizarocha.com.br/blog/sindrome-intestino-irritavel-sintomas-diagnostico-tratamento,"Síndrome do Intestino Irritável (SII): sintomas, diagnóstico e tratamento personalizado",,,,3/10/2026
+a vacina funciona em adultos,,https://www.analuizarocha.com.br/blog/hpv-anal-condilomas-riscos-tratamento-rastreio,"HPV anal e condilomas: o que são, riscos, tratamento e importância do rastreio",,,,3/10/2026
+acompanhamento significa consulta frequente,,https://www.analuizarocha.com.br/blog/o-que-muda-acompanhamento-especializado-coloproctologista-curitiba,O que muda quando você tem acompanhamento especializado?,,,,3/10/2026
+alimentação e saúde intestinal,,https://www.analuizarocha.com.br/blog/alimentacao-e-saude-intestinal,"Alimentação e saúde intestinal: fibras, hidratação e ritmo para um intestino equilibrado",,,,3/10/2026
+alterações anais podem afetar a vida sexual,,https://www.analuizarocha.com.br/blog/saude-sexual-cuidado-informacao-bem-estar,"Saúde sexual: cuidado, informação e bem-estar",,,,3/10/2026
+ansiedade causa sii,,https://www.analuizarocha.com.br/blog/sindrome-intestino-irritavel-sintomas-diagnostico-tratamento,"Síndrome do Intestino Irritável (SII): sintomas, diagnóstico e tratamento personalizado",,,,3/10/2026
+beber mais água ajuda meu intestino,,https://www.analuizarocha.com.br/blog/alimentacao-e-saude-intestinal,"Alimentação e saúde intestinal: fibras, hidratação e ritmo para um intestino equilibrado",,,,3/10/2026
+beber pouca água interfere no efeito das fibras,,https://www.analuizarocha.com.br/blog/alimentacao-fibras-saude-intestinal,Alimentação e saúde intestinal: o papel das fibras no funcionamento do intestino,,,,3/10/2026
+blog coloproctologia,,https://www.analuizarocha.com.br/blog,Blog de Coloproctologia e Saúde Intestinal,,,,3/10/2026
+cancer anal HPV,,https://www.analuizarocha.com.br/blog/hpv-anal-condilomas-riscos-tratamento-rastreio,"HPV anal e condilomas: o que são, riscos, tratamento e importância do rastreio",,,,3/10/2026
+câncer colorretal,,https://www.analuizarocha.com.br/blog/cancer-colorretal-rastreio-prevencao-diagnostico-precoce,"Câncer colorretal: rastreio, prevenção e a importância do diagnóstico precoce",,,,3/10/2026
+causas coceira anal,,https://www.analuizarocha.com.br/blog/coceira-anal-quando-procurar-coloproctologista-curitiba,Coceira anal: quando é normal e quando procurar um coloproctologista em Curitiba,,,,3/10/2026
+causas constipação intestinal,,https://www.analuizarocha.com.br/blog/constipacao-intestinal-cronica-causas-tratamento,"Constipação intestinal crônica: causas, tratamentos e quando procurar especialista",,,,3/10/2026
+causas sangue fezes,,https://www.analuizarocha.com.br/blog/sangue-nas-fezes-quando-procurar-coloproctologista,Sangue nas fezes: quando se preocupar e buscar ajuda especializada,,,,3/10/2026
+cirurgia laser coloproctologia,,https://www.analuizarocha.com.br/blog,Blog de Coloproctologia e Saúde Intestinal,,,,3/10/2026
+coceira anal,,https://www.analuizarocha.com.br/blog/coceira-anal-quando-procurar-coloproctologista-curitiba,Coceira anal: quando é normal e quando procurar um coloproctologista em Curitiba,,,,3/10/2026
+coceira anal é sempre sinal de doença,,https://www.analuizarocha.com.br/blog/coceira-anal-quando-procurar-coloproctologista-curitiba,Coceira anal: quando é normal e quando procurar um coloproctologista em Curitiba,,,,3/10/2026
+colonoscopia preventiva,,https://www.analuizarocha.com.br/blog/cancer-colorretal-rastreio-prevencao-diagnostico-precoce,"Câncer colorretal: rastreio, prevenção e a importância do diagnóstico precoce",,,,3/10/2026
+com que frequência devo repetir a colonoscopia,,https://www.analuizarocha.com.br/blog/cancer-colorretal-rastreio-prevencao-diagnostico-precoce,"Câncer colorretal: rastreio, prevenção e a importância do diagnóstico precoce",,,,3/10/2026
+com que idade devo começar consultas de rotina,,https://www.analuizarocha.com.br/blog/quando-procurar-coloproctologista-curitiba,Quando procurar um coloproctologista: guia completo,,,,3/10/2026
+comer muita fibra pode causar gases,,https://www.analuizarocha.com.br/blog/alimentacao-fibras-saude-intestinal,Alimentação e saúde intestinal: o papel das fibras no funcionamento do intestino,,,,3/10/2026
+como melhorar o intestino,,https://www.analuizarocha.com.br/blog/alimentacao-e-saude-intestinal,"Alimentação e saúde intestinal: fibras, hidratação e ritmo para um intestino equilibrado",,,,3/10/2026
+condilomas anais,,https://www.analuizarocha.com.br/blog/hpv-anal-condilomas-riscos-tratamento-rastreio,"HPV anal e condilomas: o que são, riscos, tratamento e importância do rastreio",,,,3/10/2026
+condilomas podem voltar após o tratamento,,https://www.analuizarocha.com.br/blog/hpv-anal-condilomas-riscos-tratamento-rastreio,"HPV anal e condilomas: o que são, riscos, tratamento e importância do rastreio",,,,3/10/2026
+constipação intestinal crônica,,https://www.analuizarocha.com.br/blog/constipacao-intestinal-cronica-causas-tratamento,"Constipação intestinal crônica: causas, tratamentos e quando procurar especialista",,,,3/10/2026
+constipação tratamento,,https://www.analuizarocha.com.br/blog/alimentacao-fibras-saude-intestinal,Alimentação e saúde intestinal: o papel das fibras no funcionamento do intestino,,,,3/10/2026
+consulta com coloproctologista,,https://www.analuizarocha.com.br/blog/sinto-vergonha-procurar-coloproctologista-isso-e-normal,Sinto vergonha de procurar um coloproctologista. Isso é normal?,,,,3/10/2026
+crohn e retocolite ulcerativa são a mesma doença,,https://www.analuizarocha.com.br/blog/doencas-inflamatorias-intestinais-acompanhamento,Doenças inflamatórias intestinais (DII): acompanhamento especializado,,,,3/10/2026
+diagnóstico precoce câncer de intestino,,https://www.analuizarocha.com.br/blog/cancer-colorretal-rastreio-prevencao-diagnostico-precoce,"Câncer colorretal: rastreio, prevenção e a importância do diagnóstico precoce",,,,3/10/2026
+diagnóstico SII,,https://www.analuizarocha.com.br/blog/sindrome-intestino-irritavel-sintomas-diagnostico-tratamento,"Síndrome do Intestino Irritável (SII): sintomas, diagnóstico e tratamento personalizado",,,,3/10/2026
+diarreia crônica pode ser apenas nervosa,,https://www.analuizarocha.com.br/blog/diarreia-cronica-tratamento,"Diarreia crônica: causas, diagnóstico e tratamentos",,,,3/10/2026
+diarreia crônica pode ser câncer,,https://www.analuizarocha.com.br/blog/diarreia-cronica-tratamento,"Diarreia crônica: causas, diagnóstico e tratamentos",,,,3/10/2026
+dieta para constipação,,https://www.analuizarocha.com.br/blog/alimentacao-e-saude-intestinal,"Alimentação e saúde intestinal: fibras, hidratação e ritmo para um intestino equilibrado",,,,3/10/2026
+dieta sozinha é suficiente para tratar sibo,,https://www.analuizarocha.com.br/blog/disbiose-sibo-tratamento,"Disbiose e SIBO: entenda as causas, sintomas e tratamentos",,,,3/10/2026
+disbiose e sibo são a mesma coisa,,https://www.analuizarocha.com.br/blog/disbiose-sibo-tratamento,"Disbiose e SIBO: entenda as causas, sintomas e tratamentos",,,,3/10/2026
+disbiose intestinal,,https://www.analuizarocha.com.br/blog/disbiose-sibo-tratamento,"Disbiose e SIBO: entenda as causas, sintomas e tratamentos",,,,3/10/2026
+disfunção evacuatória,,https://www.analuizarocha.com.br/blog/disturbios-assoalho-pelvico-funcionamento-intestino,Distúrbios do assoalho pélvico: quando a musculatura interfere no funcionamento do intestino,,,,3/10/2026
+distúrbios do assoalho pélvico,,https://www.analuizarocha.com.br/blog/disturbios-assoalho-pelvico-funcionamento-intestino,Distúrbios do assoalho pélvico: quando a musculatura interfere no funcionamento do intestino,,,,3/10/2026
+distúrbios do assoalho pélvico têm tratamento,,https://www.analuizarocha.com.br/blog/disturbios-assoalho-pelvico-funcionamento-intestino,Distúrbios do assoalho pélvico: quando a musculatura interfere no funcionamento do intestino,,,,3/10/2026
+doença de crohn e retocolite ulcerativa têm cura,,https://www.analuizarocha.com.br/blog/doencas-inflamatorias-intestinais-acompanhamento,Doenças inflamatórias intestinais (DII): acompanhamento especializado,,,,3/10/2026
+doença de crohn muda o tratamento da fístula,,https://www.analuizarocha.com.br/blog/tratamento-fistulas-anorretais,Tratamento de fístulas anorretais,,,,3/10/2026
+doenças orificiais,,https://www.analuizarocha.com.br/blog/coceira-anal-quando-procurar-coloproctologista-curitiba,Coceira anal: quando é normal e quando procurar um coloproctologista em Curitiba,,,,3/10/2026
+dor ao evacuar é normal,,https://www.analuizarocha.com.br/blog/quando-intestino-da-sinais-de-alerta-coloproctologista-curitiba,Quando o intestino dá sinais de alerta?,,,,3/10/2026
+dor durante a relação sexual é normal,,https://www.analuizarocha.com.br/blog/saude-sexual-cuidado-informacao-bem-estar,"Saúde sexual: cuidado, informação e bem-estar",,,,3/10/2026
+dor na relação sexual,,https://www.analuizarocha.com.br/blog/saude-sexual-cuidado-informacao-bem-estar,"Saúde sexual: cuidado, informação e bem-estar",,,,3/10/2026
+é normal ter coceira anal à noite,,https://www.analuizarocha.com.br/blog/coceira-anal-quando-procurar-coloproctologista-curitiba,Coceira anal: quando é normal e quando procurar um coloproctologista em Curitiba,,,,3/10/2026
+é normal ter vergonha de fazer exame proctológico,,https://www.analuizarocha.com.br/blog/sinto-vergonha-procurar-coloproctologista-isso-e-normal,Sinto vergonha de procurar um coloproctologista. Isso é normal?,,,,3/10/2026
+eixo intestino cérebro,,https://www.analuizarocha.com.br/blog/sindrome-intestino-irritavel-sintomas-diagnostico-tratamento,"Síndrome do Intestino Irritável (SII): sintomas, diagnóstico e tratamento personalizado",,,,3/10/2026
+especialista cólon reto,,https://www.analuizarocha.com.br/blog/quando-procurar-coloproctologista-curitiba,Quando procurar um coloproctologista: guia completo,,,,3/10/2026
+especialista em coloproctologia com formação internacional,,https://www.analuizarocha.com.br/sobre,Sobre a Dra. Ana Luiza M. Rocha | Especialista em Coloproctologia,,,,3/10/2026
+esses distúrbios podem piorar com o tempo,,https://www.analuizarocha.com.br/blog/disturbios-assoalho-pelvico-funcionamento-intestino,Distúrbios do assoalho pélvico: quando a musculatura interfere no funcionamento do intestino,,,,3/10/2026
+evacuação incompleta,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+exame proctológico,,https://www.analuizarocha.com.br/blog/sinto-vergonha-procurar-coloproctologista-isso-e-normal,Sinto vergonha de procurar um coloproctologista. Isso é normal?,,,,3/10/2026
+exames normais significam que está tudo bem,,https://www.analuizarocha.com.br/blog/por-que-meus-sintomas-nunca-melhoram,Por que meus sintomas nunca melhoram?,,,,3/10/2026
+existe tratamento para melhorar o conforto sexual,,https://www.analuizarocha.com.br/blog/saude-sexual-cuidado-informacao-bem-estar,"Saúde sexual: cuidado, informação e bem-estar",,,,3/10/2026
+fibras alimentares,,https://www.analuizarocha.com.br/blog/alimentacao-fibras-saude-intestinal,Alimentação e saúde intestinal: o papel das fibras no funcionamento do intestino,,,,3/10/2026
+fibras intestino,,https://www.analuizarocha.com.br/blog/alimentacao-e-saude-intestinal,"Alimentação e saúde intestinal: fibras, hidratação e ritmo para um intestino equilibrado",,,,3/10/2026
+fibras solúveis insolúveis,,https://www.analuizarocha.com.br/blog/alimentacao-fibras-saude-intestinal,Alimentação e saúde intestinal: o papel das fibras no funcionamento do intestino,,,,3/10/2026
+fisioterapia pélvica,,https://www.analuizarocha.com.br/blog/disturbios-assoalho-pelvico-funcionamento-intestino,Distúrbios do assoalho pélvico: quando a musculatura interfere no funcionamento do intestino,,,,3/10/2026
+fisioterapia pélvica realmente funciona,,https://www.analuizarocha.com.br/blog/disturbios-assoalho-pelvico-funcionamento-intestino,Distúrbios do assoalho pélvico: quando a musculatura interfere no funcionamento do intestino,,,,3/10/2026
+fístula anal melhora sozinha,,https://www.analuizarocha.com.br/blog/tratamento-fistulas-anorretais,Tratamento de fístulas anorretais,,,,3/10/2026
+hemorroida externa sempre precisa operar,,https://www.analuizarocha.com.br/blog/hemorroida-sempre-cirurgica-tratamento,Hemorroida é sempre cirúrgica? Entenda quando operar e opções de tratamento,,,,3/10/2026
+hemorroida sangramento,,https://www.analuizarocha.com.br/blog/sangue-nas-fezes-quando-procurar-coloproctologista,Sangue nas fezes: quando se preocupar e buscar ajuda especializada,,,,3/10/2026
+hemorroida sempre volta,,https://www.analuizarocha.com.br/blog/por-que-meus-sintomas-nunca-melhoram,Por que meus sintomas nunca melhoram?,,,,3/10/2026
+hidratação e intestino,,https://www.analuizarocha.com.br/blog/alimentacao-e-saude-intestinal,"Alimentação e saúde intestinal: fibras, hidratação e ritmo para um intestino equilibrado",,,,3/10/2026
+hpv anal sempre causa verrugas,,https://www.analuizarocha.com.br/blog/hpv-anal-condilomas-riscos-tratamento-rastreio,"HPV anal e condilomas: o que são, riscos, tratamento e importância do rastreio",,,,3/10/2026
+hpv anal sempre evolui para câncer,,https://www.analuizarocha.com.br/blog/hpv-anal-condilomas-riscos-tratamento-rastreio,"HPV anal e condilomas: o que são, riscos, tratamento e importância do rastreio",,,,3/10/2026
+inchaço abdominal tratamento,,https://www.analuizarocha.com.br/blog/disbiose-sibo-tratamento,"Disbiose e SIBO: entenda as causas, sintomas e tratamentos",,,,3/10/2026
+incontinencia fecal,,https://www.analuizarocha.com.br/blog/disturbios-assoalho-pelvico-funcionamento-intestino,Distúrbios do assoalho pélvico: quando a musculatura interfere no funcionamento do intestino,,,,3/10/2026
+incontinência fecal,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+incontinência fecal é normal com a idade,,https://www.analuizarocha.com.br/blog/disturbios-assoalho-pelvico-funcionamento-intestino,Distúrbios do assoalho pélvico: quando a musculatura interfere no funcionamento do intestino,,,,3/10/2026
+IST anal,,https://www.analuizarocha.com.br/blog/saude-sexual-cuidado-informacao-bem-estar,"Saúde sexual: cuidado, informação e bem-estar",,,,3/10/2026
+mesmo em remissão preciso continuar acompanhamento,,https://www.analuizarocha.com.br/blog/doencas-inflamatorias-intestinais-acompanhamento,Doenças inflamatórias intestinais (DII): acompanhamento especializado,,,,3/10/2026
+microbiota intestinal,,https://www.analuizarocha.com.br/blog/disbiose-sibo-tratamento,"Disbiose e SIBO: entenda as causas, sintomas e tratamentos",,,,3/10/2026
+mudança no hábito intestinal,,https://www.analuizarocha.com.br/blog/quando-intestino-da-sinais-de-alerta-coloproctologista-curitiba,Quando o intestino dá sinais de alerta?,,,,3/10/2026
+mudança no hábito intestinal pode ser estresse,,https://www.analuizarocha.com.br/blog/quando-intestino-da-sinais-de-alerta-coloproctologista-curitiba,Quando o intestino dá sinais de alerta?,,,,3/10/2026
+o acompanhamento evita cirurgia,,https://www.analuizarocha.com.br/blog/o-que-muda-acompanhamento-especializado-coloproctologista-curitiba,O que muda quando você tem acompanhamento especializado?,,,,3/10/2026
+o cisto pilonidal some sozinho,,https://www.analuizarocha.com.br/blog/cisto-pilonidal-cirurgia-laser-quando-operar,"Cisto pilonidal: o que é, por que acontece e quando é a melhor hora de operar",,,,3/10/2026
+o exame proctológico dói,,https://www.analuizarocha.com.br/blog/quando-procurar-coloproctologista-curitiba,Quando procurar um coloproctologista: guia completo,,,,3/10/2026
+o médico vai me julgar,,https://www.analuizarocha.com.br/blog/sinto-vergonha-procurar-coloproctologista-isso-e-normal,Sinto vergonha de procurar um coloproctologista. Isso é normal?,,,,3/10/2026
+o plicoma pode virar câncer,,https://www.analuizarocha.com.br/blog/plicoma-anal-cirurgia-laser,Plicoma anal: o que é e como a cirurgia a laser pode auxiliar na recuperação,,,,3/10/2026
+o que devo comer quando estou com diarreia frequente,,https://www.analuizarocha.com.br/blog/diarreia-cronica-tratamento,"Diarreia crônica: causas, diagnóstico e tratamentos",,,,3/10/2026
+o que devo levar para minha primeira consulta,,https://www.analuizarocha.com.br/blog/quando-procurar-coloproctologista-curitiba,Quando procurar um coloproctologista: guia completo,,,,3/10/2026
+o que posso fazer para prevenir a coceira anal,,https://www.analuizarocha.com.br/blog/coceira-anal-quando-procurar-coloproctologista-curitiba,Coceira anal: quando é normal e quando procurar um coloproctologista em Curitiba,,,,3/10/2026
+o rastreio é necessário mesmo sem sintomas,,https://www.analuizarocha.com.br/blog/cancer-colorretal-rastreio-prevencao-diagnostico-precoce,"Câncer colorretal: rastreio, prevenção e a importância do diagnóstico precoce",,,,3/10/2026
+o sangue pode aparecer mesmo sem dor,,https://www.analuizarocha.com.br/blog/sangue-nas-fezes-quando-procurar-coloproctologista,Sangue nas fezes: quando se preocupar e buscar ajuda especializada,,,,3/10/2026
+para que serve o seton,,https://www.analuizarocha.com.br/blog/tratamento-fistulas-anorretais,Tratamento de fístulas anorretais,,,,3/10/2026
+pólipos intestinais,,https://www.analuizarocha.com.br/blog/cancer-colorretal-rastreio-prevencao-diagnostico-precoce,"Câncer colorretal: rastreio, prevenção e a importância do diagnóstico precoce",,,,3/10/2026
+posso falar sobre práticas sexuais na consulta,,https://www.analuizarocha.com.br/blog/saude-sexual-cuidado-informacao-bem-estar,"Saúde sexual: cuidado, informação e bem-estar",,,,3/10/2026
+posso operar durante uma crise hemorroidária,,https://www.analuizarocha.com.br/blog/hemorroida-sempre-cirurgica-tratamento,Hemorroida é sempre cirúrgica? Entenda quando operar e opções de tratamento,,,,3/10/2026
+posso usar laxantes naturais todos os dias,,https://www.analuizarocha.com.br/blog/alimentacao-e-saude-intestinal,"Alimentação e saúde intestinal: fibras, hidratação e ritmo para um intestino equilibrado",,,,3/10/2026
+posso usar laxantes por conta própria,,https://www.analuizarocha.com.br/blog/constipacao-intestinal-cronica-causas-tratamento,"Constipação intestinal crônica: causas, tratamentos e quando procurar especialista",,,,3/10/2026
+posso usar pomadas por conta própria,,https://www.analuizarocha.com.br/blog/coceira-anal-quando-procurar-coloproctologista-curitiba,Coceira anal: quando é normal e quando procurar um coloproctologista em Curitiba,,,,3/10/2026
+preciso fazer colonoscopia se tiver sangue nas fezes,,https://www.analuizarocha.com.br/blog/sangue-nas-fezes-quando-procurar-coloproctologista,Sangue nas fezes: quando se preocupar e buscar ajuda especializada,,,,3/10/2026
+preciso fazer exame já na primeira consulta,,https://www.analuizarocha.com.br/blog/sinto-vergonha-procurar-coloproctologista-isso-e-normal,Sinto vergonha de procurar um coloproctologista. Isso é normal?,,,,3/10/2026
+preciso mesmo procurar um coloproctologista se o sangramento for pequeno,,https://www.analuizarocha.com.br/blog/quando-procurar-coloproctologista-curitiba,Quando procurar um coloproctologista: guia completo,,,,3/10/2026
+preciso obrigatoriamente retirar o plicoma,,https://www.analuizarocha.com.br/blog/plicoma-anal-cirurgia-laser,Plicoma anal: o que é e como a cirurgia a laser pode auxiliar na recuperação,,,,3/10/2026
+preciso operar mesmo sem sintomas agora,,https://www.analuizarocha.com.br/blog/cisto-pilonidal-cirurgia-laser-quando-operar,"Cisto pilonidal: o que é, por que acontece e quando é a melhor hora de operar",,,,3/10/2026
+preciso retornar mesmo se estiver melhor,,https://www.analuizarocha.com.br/blog/o-que-muda-acompanhamento-especializado-coloproctologista-curitiba,O que muda quando você tem acompanhamento especializado?,,,,3/10/2026
+prevenção câncer colorretal,,https://www.analuizarocha.com.br/blog,Blog de Coloproctologia e Saúde Intestinal,,,,3/10/2026
+prevenção hemorroidas,,https://www.analuizarocha.com.br/blog/alimentacao-fibras-saude-intestinal,Alimentação e saúde intestinal: o papel das fibras no funcionamento do intestino,,,,3/10/2026
+prisão de ventre é sempre causada por má alimentação,,https://www.analuizarocha.com.br/blog/constipacao-intestinal-cronica-causas-tratamento,"Constipação intestinal crônica: causas, tratamentos e quando procurar especialista",,,,3/10/2026
+prisão de ventre tratamento,,https://www.analuizarocha.com.br/blog/constipacao-intestinal-cronica-causas-tratamento,"Constipação intestinal crônica: causas, tratamentos e quando procurar especialista",,,,3/10/2026
+probióticos resolvem sibo,,https://www.analuizarocha.com.br/blog/disbiose-sibo-tratamento,"Disbiose e SIBO: entenda as causas, sintomas e tratamentos",,,,3/10/2026
+problemas intestinais,,https://www.analuizarocha.com.br/blog/quando-procurar-coloproctologista-curitiba,Quando procurar um coloproctologista: guia completo,,,,3/10/2026
+prurido anal,,https://www.analuizarocha.com.br/blog/coceira-anal-quando-procurar-coloproctologista-curitiba,Coceira anal: quando é normal e quando procurar um coloproctologista em Curitiba,,,,3/10/2026
+qual a quantidade ideal de fibras por dia,,https://www.analuizarocha.com.br/blog/alimentacao-fibras-saude-intestinal,Alimentação e saúde intestinal: o papel das fibras no funcionamento do intestino,,,,3/10/2026
+quando a colonoscopia é indicada,,https://www.analuizarocha.com.br/blog/diarreia-cronica-tratamento,"Diarreia crônica: causas, diagnóstico e tratamentos",,,,3/10/2026
+quando devo procurar um coloproctologista,,https://www.analuizarocha.com.br/blog/constipacao-intestinal-cronica-causas-tratamento,"Constipação intestinal crônica: causas, tratamentos e quando procurar especialista",,,,3/10/2026
+quando devo procurar um coloproctologista em curitiba,,https://www.analuizarocha.com.br/blog/fissura-anal-tratamento,"Fissura anal: sintomas, tratamentos e como a coloproctologia pode ajudar",,,,3/10/2026
+quando é indicado o uso de toxina botulínica,,https://www.analuizarocha.com.br/blog/fissura-anal-tratamento,"Fissura anal: sintomas, tratamentos e como a coloproctologia pode ajudar",,,,3/10/2026
+quando é urgente procurar atendimento,,https://www.analuizarocha.com.br/blog/quando-intestino-da-sinais-de-alerta-coloproctologista-curitiba,Quando o intestino dá sinais de alerta?,,,,3/10/2026
+quando ir ao proctologista,,https://www.analuizarocha.com.br/blog/quando-procurar-coloproctologista-curitiba,Quando procurar um coloproctologista: guia completo,,,,3/10/2026
+quando preocupar sangramento,,https://www.analuizarocha.com.br/blog/sangue-nas-fezes-quando-procurar-coloproctologista,Sangue nas fezes: quando se preocupar e buscar ajuda especializada,,,,3/10/2026
+quando procurar coloproctologista,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+quanta fibra devo consumir por dia,,https://www.analuizarocha.com.br/blog/alimentacao-e-saude-intestinal,"Alimentação e saúde intestinal: fibras, hidratação e ritmo para um intestino equilibrado",,,,3/10/2026
+quanto tempo dura a recuperação da cirurgia a laser,,https://www.analuizarocha.com.br/blog/plicoma-anal-cirurgia-laser,Plicoma anal: o que é e como a cirurgia a laser pode auxiliar na recuperação,,,,3/10/2026
+quanto tempo para recuperar,,https://www.analuizarocha.com.br/blog/cisto-pilonidal-cirurgia-laser-quando-operar,"Cisto pilonidal: o que é, por que acontece e quando é a melhor hora de operar",,,,3/10/2026
+quem é dra ana luiza,,https://www.analuizarocha.com.br/sobre,Sobre a Dra. Ana Luiza M. Rocha | Especialista em Coloproctologia,,,,3/10/2026
+rastreio câncer colorretal,,https://www.analuizarocha.com.br/blog/cancer-colorretal-rastreio-prevencao-diagnostico-precoce,"Câncer colorretal: rastreio, prevenção e a importância do diagnóstico precoce",,,,3/10/2026
+rastreio HPV anal,,https://www.analuizarocha.com.br/blog/hpv-anal-condilomas-riscos-tratamento-rastreio,"HPV anal e condilomas: o que são, riscos, tratamento e importância do rastreio",,,,3/10/2026
+ritmo intestinal,,https://www.analuizarocha.com.br/blog/alimentacao-e-saude-intestinal,"Alimentação e saúde intestinal: fibras, hidratação e ritmo para um intestino equilibrado",,,,3/10/2026
+sangramento anal,,https://www.analuizarocha.com.br/blog/sangue-nas-fezes-quando-procurar-coloproctologista,Sangue nas fezes: quando se preocupar e buscar ajuda especializada,,,,3/10/2026
+sangramento ao evacuar,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+sangue nas fezes,,https://www.analuizarocha.com.br/blog/sangue-nas-fezes-quando-procurar-coloproctologista,Sangue nas fezes: quando se preocupar e buscar ajuda especializada,,,,3/10/2026
+sangue nas fezes sempre é hemorroida,,https://www.analuizarocha.com.br/blog/quando-intestino-da-sinais-de-alerta-coloproctologista-curitiba,Quando o intestino dá sinais de alerta?,,,,3/10/2026
+sangue nas fezes sempre significa câncer,,https://www.analuizarocha.com.br/blog/sangue-nas-fezes-quando-procurar-coloproctologista,Sangue nas fezes: quando se preocupar e buscar ajuda especializada,,,,3/10/2026
+saúde anorretal,,https://www.analuizarocha.com.br/blog/saude-sexual-cuidado-informacao-bem-estar,"Saúde sexual: cuidado, informação e bem-estar",,,,3/10/2026
+saúde intestinal,,https://www.analuizarocha.com.br/blog/alimentacao-fibras-saude-intestinal,Alimentação e saúde intestinal: o papel das fibras no funcionamento do intestino,,,,3/10/2026
+saúde sexual,,https://www.analuizarocha.com.br/blog/saude-sexual-cuidado-informacao-bem-estar,"Saúde sexual: cuidado, informação e bem-estar",,,,3/10/2026
+saúde sexual coloproctologia,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+se eu tiver pólipos é câncer,,https://www.analuizarocha.com.br/blog/cancer-colorretal-rastreio-prevencao-diagnostico-precoce,"Câncer colorretal: rastreio, prevenção e a importância do diagnóstico precoce",,,,3/10/2026
+sibo sintomas,,https://www.analuizarocha.com.br/blog/disbiose-sibo-tratamento,"Disbiose e SIBO: entenda as causas, sintomas e tratamentos",,,,3/10/2026
+sibo tem cura,,https://www.analuizarocha.com.br/blog/disbiose-sibo-tratamento,"Disbiose e SIBO: entenda as causas, sintomas e tratamentos",,,,3/10/2026
+SII sintomas,,https://www.analuizarocha.com.br/blog/sindrome-intestino-irritavel-sintomas-diagnostico-tratamento,"Síndrome do Intestino Irritável (SII): sintomas, diagnóstico e tratamento personalizado",,,,3/10/2026
+sinais de alerta intestinais,,https://www.analuizarocha.com.br/blog/quando-intestino-da-sinais-de-alerta-coloproctologista-curitiba,Quando o intestino dá sinais de alerta?,,,,3/10/2026
+sinais e sintomas intestinais,,https://www.analuizarocha.com.br/,Dra. Ana Luiza M. Rocha | Coloproctologista Curitiba,,,,3/10/2026
+síndrome do intestino irritável,,https://www.analuizarocha.com.br/blog/sindrome-intestino-irritavel-sintomas-diagnostico-tratamento,"Síndrome do Intestino Irritável (SII): sintomas, diagnóstico e tratamento personalizado",,,,3/10/2026
+síndrome do intestino irritável é doença grave,,https://www.analuizarocha.com.br/blog/sindrome-intestino-irritavel-sintomas-diagnostico-tratamento,"Síndrome do Intestino Irritável (SII): sintomas, diagnóstico e tratamento personalizado",,,,3/10/2026
+sintomas coloproctologia,,https://www.analuizarocha.com.br/blog/quando-procurar-coloproctologista-curitiba,Quando procurar um coloproctologista: guia completo,,,,3/10/2026
+sintomas intestinais persistentes podem ser graves,,https://www.analuizarocha.com.br/blog/por-que-meus-sintomas-nunca-melhoram,Por que meus sintomas nunca melhoram?,,,,3/10/2026
+sintomas prisão de ventre,,https://www.analuizarocha.com.br/blog/constipacao-intestinal-cronica-causas-tratamento,"Constipação intestinal crônica: causas, tratamentos e quando procurar especialista",,,,3/10/2026
+supercrescimento bacteriano,,https://www.analuizarocha.com.br/blog/disbiose-sibo-tratamento,"Disbiose e SIBO: entenda as causas, sintomas e tratamentos",,,,3/10/2026
+suplementos de fibras funcionam,,https://www.analuizarocha.com.br/blog/alimentacao-fibras-saude-intestinal,Alimentação e saúde intestinal: o papel das fibras no funcionamento do intestino,,,,3/10/2026
+tenho vergonha de falar sobre meus sintomas o que fazer,,https://www.analuizarocha.com.br/blog/quando-procurar-coloproctologista-curitiba,Quando procurar um coloproctologista: guia completo,,,,3/10/2026
+toda fístula precisa de cirurgia,,https://www.analuizarocha.com.br/blog/tratamento-fistulas-anorretais,Tratamento de fístulas anorretais,,,,3/10/2026
+toda hemorroida precisa de cirurgia,,https://www.analuizarocha.com.br/blog/hemorroida-sempre-cirurgica-tratamento,Hemorroida é sempre cirúrgica? Entenda quando operar e opções de tratamento,,,,3/10/2026
+todo paciente com dii precisa de cirurgia,,https://www.analuizarocha.com.br/blog/doencas-inflamatorias-intestinais-acompanhamento,Doenças inflamatórias intestinais (DII): acompanhamento especializado,,,,3/10/2026
+tratamento hemorroidas,,https://www.analuizarocha.com.br/blog,Blog de Coloproctologia e Saúde Intestinal,,,,3/10/2026
+tratamento intestino preso,,https://www.analuizarocha.com.br/blog/constipacao-intestinal-cronica-causas-tratamento,"Constipação intestinal crônica: causas, tratamentos e quando procurar especialista",,,,3/10/2026
+tratamento prurido anal,,https://www.analuizarocha.com.br/blog/coceira-anal-quando-procurar-coloproctologista-curitiba,Coceira anal: quando é normal e quando procurar um coloproctologista em Curitiba,,,,3/10/2026
+tratamento síndrome do intestino irritável,,https://www.analuizarocha.com.br/blog/sindrome-intestino-irritavel-sintomas-diagnostico-tratamento,"Síndrome do Intestino Irritável (SII): sintomas, diagnóstico e tratamento personalizado",,,,3/10/2026
+usar laxante todos os dias faz mal,,https://www.analuizarocha.com.br/blog/por-que-meus-sintomas-nunca-melhoram,Por que meus sintomas nunca melhoram?,,,,3/10/2026
+vacina HPV adultos,,https://www.analuizarocha.com.br/blog/hpv-anal-condilomas-riscos-tratamento-rastreio,"HPV anal e condilomas: o que são, riscos, tratamento e importância do rastreio",,,,3/10/2026
+vale a pena mesmo quando o problema parece simples,,https://www.analuizarocha.com.br/blog/o-que-muda-acompanhamento-especializado-coloproctologista-curitiba,O que muda quando você tem acompanhamento especializado?,,,,3/10/2026
+vergonha de procurar coloproctologista,,https://www.analuizarocha.com.br/blog/sinto-vergonha-procurar-coloproctologista-isso-e-normal,Sinto vergonha de procurar um coloproctologista. Isso é normal?,,,,3/10/2026

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image'
 import Link from 'next/link'
 import { MDXRemote } from 'next-mdx-remote/rsc'
 import { Badge } from '@/components/ui/Badge'
@@ -96,32 +97,54 @@ export default function BlogPage() {
               </p>
             </div>
           ) : (
-            <div className="mx-auto max-w-4xl space-y-8 lg:space-y-12">
+            <div className="mx-auto max-w-6xl grid grid-cols-1 gap-6 md:grid-cols-2 lg:gap-8">
               {posts.map((post) => (
                 <article
                   key={post.slug}
-                  className="bg-secondary/10 rounded-3xl p-8 lg:p-10 border border-secondary/20 hover:border-secondary/30 transition-all duration-300 shadow-sm hover:shadow-md group"
+                  className="group overflow-hidden rounded-3xl border border-secondary/20 bg-card-bg shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-secondary/35 hover:shadow-lg"
                 >
-                  <div className="mb-6">
-                    <div className="flex items-center gap-4 text-sm text-secondary mb-4">
+                  <div className="relative aspect-[16/10] overflow-hidden bg-secondary/15">
+                    {post.cardImage ? (
+                      <Link
+                        href={`/blog/${post.slug}`}
+                        className="absolute inset-0 block"
+                        aria-label={`Abrir artigo: ${post.title}`}
+                      >
+                        <Image
+                          src={post.cardImage.src}
+                          alt={post.cardImage.alt}
+                          fill
+                          className="object-cover transition-transform duration-500 group-hover:scale-105"
+                          sizes="(min-width: 1280px) 36rem, (min-width: 768px) 50vw, 100vw"
+                        />
+                      </Link>
+                    ) : (
+                      <div className="h-full w-full bg-gradient-to-br from-secondary/35 via-background to-secondary/5" />
+                    )}
+                  </div>
+
+                  <div className="p-5 lg:p-6">
+                    <div className="mb-3 flex items-center gap-4 text-sm text-text-muted">
                       <time dateTime={post.publishDate}>
-                        {new Date(post.publishDate).toLocaleDateString('pt-BR')}
+                        {new Date(post.publishDate).toLocaleDateString('pt-BR', {
+                          timeZone: 'UTC',
+                        })}
                       </time>
                       {post.readingTime && (
                         <span>{post.readingTime} min de leitura</span>
                       )}
                     </div>
 
-                    <h2 className="text-2xl lg:text-3xl font-serif font-bold text-primary mb-4 group-hover:text-primary/90 transition-colors">
+                    <h2 className="mb-3 text-2xl font-serif font-bold text-primary transition-colors group-hover:text-primary/90">
                       <Link href={`/blog/${post.slug}`}>{post.title}</Link>
                     </h2>
 
-                    <div className="prose prose-lg max-w-none mb-6">
+                    <div className="prose prose-sm mb-5 max-w-none text-text-body [&_p]:mb-0">
                       <MDXRemote source={post.excerpt} />
                     </div>
 
-                    <div className="flex items-center justify-between">
-                      <div className="flex flex-wrap gap-2 mr-4">
+                    <div className="flex items-end justify-between gap-4">
+                      <div className="mr-4 flex flex-wrap gap-2">
                         <Badge variant="primary">
                           {getContentIntentLabel(post.intent)}
                         </Badge>
@@ -132,7 +155,7 @@ export default function BlogPage() {
 
                       <Link
                         href={`/blog/${post.slug}`}
-                        className="text-primary hover:text-primary/80 font-medium transition-colors text-lg text-nowrap"
+                        className="text-nowrap font-medium text-primary transition-colors hover:text-primary/80"
                       >
                         Ler artigo →
                       </Link>

--- a/src/app/tratamentos/cx-cisto-pilonidal/page.tsx
+++ b/src/app/tratamentos/cx-cisto-pilonidal/page.tsx
@@ -4,6 +4,8 @@ import { CallToActionCard } from '@/components/ui/CallToActionCard'
 import { Breadcrumb } from '@/components/ui/Breadcrumb'
 import type { Metadata } from 'next'
 import { LinkButton } from '@/components/ui/LinkButton'
+import { TreatmentHeroImage } from '@/components/ui/TreatmentHeroImage'
+import { RelatedBlogCard } from '@/components/ui/RelatedBlogCard'
 import {
   WPP_NUMBER_NASSIF,
   WHATSAPP_MSG_TEXT_ENCODED,
@@ -162,6 +164,9 @@ export default function CistoPilonidalPage() {
               </p>
             </header>
 
+            <TreatmentHeroImage slug="cx-cisto-pilonidal" />
+
+
             <main className="prose prose-lg max-w-none mb-12">
               <p>
                 Existem duas abordagens principais: a técnica&nbsp;
@@ -271,6 +276,8 @@ export default function CistoPilonidalPage() {
                   vida para o paciente.
                 </p>
               </blockquote>
+
+              <RelatedBlogCard treatmentSlug="cx-cisto-pilonidal" />
 
               <h2>Perguntas frequentes (FAQ)</h2>
 

--- a/src/app/tratamentos/cx-fistulas-anorretais/page.tsx
+++ b/src/app/tratamentos/cx-fistulas-anorretais/page.tsx
@@ -4,6 +4,8 @@ import { CallToActionCard } from '@/components/ui/CallToActionCard'
 import { Breadcrumb } from '@/components/ui/Breadcrumb'
 import type { Metadata } from 'next'
 import { LinkButton } from '@/components/ui/LinkButton'
+import { TreatmentHeroImage } from '@/components/ui/TreatmentHeroImage'
+import { RelatedBlogCard } from '@/components/ui/RelatedBlogCard'
 import {
   WPP_NUMBER_NASSIF,
   WHATSAPP_MSG_TEXT_ENCODED,
@@ -167,6 +169,9 @@ export default function CirurgiaFistulasPage() {
               </p>
             </header>
 
+            <TreatmentHeroImage slug="cx-fistulas-anorretais" />
+
+
             <main className="prose prose-lg max-w-none mb-12">
               <p>
                 Costumam surgir após abscessos anorretais e podem provocar secreção, dor e
@@ -316,6 +321,8 @@ export default function CirurgiaFistulasPage() {
                   da melhor estratégia de tratamento.
                 </p>
               </blockquote>
+
+              <RelatedBlogCard treatmentSlug="cx-fistulas-anorretais" />
 
               <h2>Perguntas frequentes (FAQ)</h2>
 

--- a/src/app/tratamentos/cx-laser/page.tsx
+++ b/src/app/tratamentos/cx-laser/page.tsx
@@ -4,6 +4,8 @@ import { CallToActionCard } from '@/components/ui/CallToActionCard'
 import { Breadcrumb } from '@/components/ui/Breadcrumb'
 import type { Metadata } from 'next'
 import { LinkButton } from '@/components/ui/LinkButton'
+import { TreatmentHeroImage } from '@/components/ui/TreatmentHeroImage'
+import { RelatedBlogCard } from '@/components/ui/RelatedBlogCard'
 import {
   WPP_NUMBER_NASSIF,
   WHATSAPP_MSG_TEXT_ENCODED,
@@ -162,6 +164,9 @@ export default function CirurgiasLaserPage() {
               </p>
             </header>
 
+            <TreatmentHeroImage slug="cx-laser" />
+
+
             <main className="prose prose-lg max-w-none mb-12">
               <h2>Principais indicações</h2>
               <p>
@@ -249,6 +254,8 @@ export default function CirurgiasLaserPage() {
                 coloproctologia moderna, trazendo mais conforto e segurança em
                 casos bem selecionados.
               </p>
+
+              <RelatedBlogCard treatmentSlug="cx-laser" />
 
               <h2>Perguntas frequentes (FAQ)</h2>
 

--- a/src/app/tratamentos/doencas-inflamatorias-intestinais/page.tsx
+++ b/src/app/tratamentos/doencas-inflamatorias-intestinais/page.tsx
@@ -4,6 +4,8 @@ import { CallToActionCard } from '@/components/ui/CallToActionCard'
 import { Breadcrumb } from '@/components/ui/Breadcrumb'
 import type { Metadata } from 'next'
 import { LinkButton } from '@/components/ui/LinkButton'
+import { TreatmentHeroImage } from '@/components/ui/TreatmentHeroImage'
+import { RelatedBlogCard } from '@/components/ui/RelatedBlogCard'
 import { WPP_NUMBER_NASSIF, WHATSAPP_MSG_TEXT_ENCODED, WEBSITE_URL } from '@/lib/constants'
 import {
   generateFAQSchema,
@@ -165,6 +167,9 @@ export default function DoencasInflamatoriasIntestinaisPage() {
               </p>
             </header>
 
+            <TreatmentHeroImage slug="doencas-inflamatorias-intestinais" />
+
+
             <main className="prose prose-lg max-w-none mb-12">
               <p>
                 Com acompanhamento adequado em <strong>coloproctologia</strong>, é possível
@@ -293,6 +298,8 @@ export default function DoencasInflamatoriasIntestinaisPage() {
                   agende sua avaliação em coloproctologia.
                 </p>
               </blockquote>
+
+              <RelatedBlogCard treatmentSlug="doencas-inflamatorias-intestinais" />
 
               <h2>Perguntas frequentes (FAQ)</h2>
 

--- a/src/app/tratamentos/hemorroidas/page.tsx
+++ b/src/app/tratamentos/hemorroidas/page.tsx
@@ -4,6 +4,8 @@ import { CallToActionCard } from '@/components/ui/CallToActionCard'
 import { Breadcrumb } from '@/components/ui/Breadcrumb'
 import type { Metadata } from 'next'
 import { LinkButton } from '@/components/ui/LinkButton'
+import { TreatmentHeroImage } from '@/components/ui/TreatmentHeroImage'
+import { RelatedBlogCard } from '@/components/ui/RelatedBlogCard'
 import {
   WPP_NUMBER_NASSIF,
   WHATSAPP_MSG_TEXT_ENCODED,
@@ -163,6 +165,9 @@ export default function TratamentoHemorroidasPage() {
                 dos sintomas e a resposta às medidas clínicas iniciais.
               </p>
             </header>
+
+            <TreatmentHeroImage slug="hemorroidas" />
+
 
             <main className="prose prose-lg max-w-none mb-12">
               <p>
@@ -336,6 +341,8 @@ export default function TratamentoHemorroidasPage() {
                 ambulatoriais até cirurgias minimamente invasivas, sempre com o
                 objetivo de oferecer segurança e qualidade de vida ao paciente.
               </p>
+
+              <RelatedBlogCard treatmentSlug="hemorroidas" />
 
               <h2>Perguntas frequentes (FAQ)</h2>
 

--- a/src/app/tratamentos/hpv-anal/page.tsx
+++ b/src/app/tratamentos/hpv-anal/page.tsx
@@ -4,6 +4,8 @@ import { CallToActionCard } from '@/components/ui/CallToActionCard'
 import { Breadcrumb } from '@/components/ui/Breadcrumb'
 import type { Metadata } from 'next'
 import { LinkButton } from '@/components/ui/LinkButton'
+import { TreatmentHeroImage } from '@/components/ui/TreatmentHeroImage'
+import { RelatedBlogCard } from '@/components/ui/RelatedBlogCard'
 import {
   WPP_NUMBER_NASSIF,
   WHATSAPP_MSG_TEXT_ENCODED,
@@ -162,6 +164,9 @@ export default function TratamentoHpvAnalPage() {
               </p>
             </header>
 
+            <TreatmentHeroImage slug="hpv-anal" />
+
+
             <main className="prose prose-lg max-w-none mb-12">
               <p>
                 Essas lesões podem provocar desconforto, sangramento, coceira e, em alguns casos,
@@ -271,6 +276,8 @@ export default function TratamentoHpvAnalPage() {
                 a melhor estratégia, garantir segurança no tratamento e reduzir o risco de
                 recidivas.
               </p>
+
+              <RelatedBlogCard treatmentSlug="hpv-anal" />
 
               <h2>Perguntas frequentes (FAQ)</h2>
 

--- a/src/app/tratamentos/page.tsx
+++ b/src/app/tratamentos/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next'
 import { WPP_NUMBER_NASSIF, WHATSAPP_MSG_TEXT_ENCODED, WEBSITE_URL } from '@/lib/constants'
 import { LinkButton } from '@/components/ui/LinkButton'
 import { TreatmentCard } from '@/components/ui/TreatmentCard'
+import { getTreatmentImageBySlug } from '@/lib/treatment-images'
 
 export const metadata: Metadata = {
   title: 'Tratamentos de Coloproctologia em Curitiba',
@@ -95,13 +96,23 @@ export default function ServicosPage() {
             '@type': 'MedicalOrganization',
             '@id': `${WEBSITE_URL}/#organization`,
             medicalSpecialty: ['Coloproctologia', 'Proctologia'],
-            availableService: treatments.map((treatment) => ({
-              '@type': 'MedicalProcedure',
-              name: treatment.title,
-              description: treatment.description,
-              procedureType: treatment.category,
-              url: `${WEBSITE_URL}/tratamentos/${treatment.slug}`,
-            })),
+            availableService: treatments.map((treatment) => {
+              const treatmentImage = getTreatmentImageBySlug(treatment.slug)
+
+              return {
+                '@type': 'MedicalProcedure',
+                name: treatment.title,
+                description: treatment.description,
+                procedureType: treatment.category,
+                ...(treatmentImage
+                  ? {
+                      identifier: treatmentImage.id,
+                      image: `${WEBSITE_URL}${treatmentImage.src}`,
+                    }
+                  : {}),
+                url: `${WEBSITE_URL}/tratamentos/${treatment.slug}`,
+              }
+            }),
           }),
         }}
       />
@@ -131,16 +142,22 @@ export default function ServicosPage() {
 
             {/* Treatments Grid */}
             <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 sm:gap-6 xl:grid-cols-3 xl:gap-8">
-              {treatments.map((treatment) => (
-                <TreatmentCard
-                  key={treatment.slug}
-                  title={treatment.title}
-                  description={treatment.description}
-                  category={treatment.category}
-                  href={`/tratamentos/${treatment.slug}`}
-                  variant="detailed"
-                />
-              ))}
+              {treatments.map((treatment) => {
+                const treatmentImage = getTreatmentImageBySlug(treatment.slug)
+
+                return (
+                  <TreatmentCard
+                    key={treatment.slug}
+                    title={treatment.title}
+                    description={treatment.description}
+                    category={treatment.category}
+                    href={`/tratamentos/${treatment.slug}`}
+                    variant="detailed"
+                    treatmentId={treatmentImage?.id}
+                    image={treatmentImage}
+                  />
+                )
+              })}
             </div>
           </div>
 

--- a/src/app/tratamentos/rastreio-cancer-anal/page.tsx
+++ b/src/app/tratamentos/rastreio-cancer-anal/page.tsx
@@ -4,6 +4,8 @@ import { CallToActionCard } from '@/components/ui/CallToActionCard'
 import { Breadcrumb } from '@/components/ui/Breadcrumb'
 import type { Metadata } from 'next'
 import { LinkButton } from '@/components/ui/LinkButton'
+import { TreatmentHeroImage } from '@/components/ui/TreatmentHeroImage'
+import { RelatedBlogCard } from '@/components/ui/RelatedBlogCard'
 import {
   WPP_NUMBER_NASSIF,
   WHATSAPP_MSG_TEXT_ENCODED,
@@ -162,6 +164,9 @@ export default function RastreioCancerAnalPage() {
               </p>
             </header>
 
+            <TreatmentHeroImage slug="rastreio-cancer-anal" />
+
+
             <main className="prose prose-lg max-w-none mb-12">
               <h2>Fatores de risco</h2>
               <p>Alguns fatores aumentam a probabilidade de desenvolver câncer de canal anal:</p>
@@ -304,6 +309,8 @@ export default function RastreioCancerAnalPage() {
                   coloproctologista para definir a melhor estratégia de acompanhamento.
                 </p>
               </blockquote>
+
+              <RelatedBlogCard treatmentSlug="rastreio-cancer-anal" />
 
               <h2>Perguntas frequentes (FAQ)</h2>
 

--- a/src/app/tratamentos/sindrome-intestino-irritavel/page.tsx
+++ b/src/app/tratamentos/sindrome-intestino-irritavel/page.tsx
@@ -4,6 +4,8 @@ import { CallToActionCard } from '@/components/ui/CallToActionCard'
 import { Breadcrumb } from '@/components/ui/Breadcrumb'
 import type { Metadata } from 'next'
 import { LinkButton } from '@/components/ui/LinkButton'
+import { TreatmentHeroImage } from '@/components/ui/TreatmentHeroImage'
+import { RelatedBlogCard } from '@/components/ui/RelatedBlogCard'
 import { WPP_NUMBER_NASSIF, WHATSAPP_MSG_TEXT_ENCODED, WEBSITE_URL } from '@/lib/constants'
 import {
   generateFAQSchema,
@@ -166,6 +168,9 @@ export default function SindromeIntestinoIrritavelPage() {
               </p>
             </header>
 
+            <TreatmentHeroImage slug="sindrome-intestino-irritavel" />
+
+
             <main className="prose prose-lg max-w-none mb-12">
               <p>
                 O diagnóstico correto e o acompanhamento com&nbsp;
@@ -284,6 +289,8 @@ export default function SindromeIntestinoIrritavelPage() {
                   descubra as melhores estratégias para o seu caso.
                 </p>
               </blockquote>
+
+              <RelatedBlogCard treatmentSlug="sindrome-intestino-irritavel" />
 
               <h2>Perguntas frequentes (FAQ)</h2>
 

--- a/src/app/tratamentos/toxina-botulinica/page.tsx
+++ b/src/app/tratamentos/toxina-botulinica/page.tsx
@@ -4,6 +4,8 @@ import { CallToActionCard } from '@/components/ui/CallToActionCard'
 import { Breadcrumb } from '@/components/ui/Breadcrumb'
 import type { Metadata } from 'next'
 import { LinkButton } from '@/components/ui/LinkButton'
+import { TreatmentHeroImage } from '@/components/ui/TreatmentHeroImage'
+import { RelatedBlogCard } from '@/components/ui/RelatedBlogCard'
 import {
   WPP_NUMBER_NASSIF,
   WHATSAPP_MSG_TEXT_ENCODED,
@@ -160,6 +162,9 @@ export default function ToxinaBotulínicaPage() {
               </p>
             </header>
 
+            <TreatmentHeroImage slug="toxina-botulinica" />
+
+
             <main className="prose prose-lg max-w-none mb-12">
               <h2>Indicações principais</h2>
 
@@ -250,6 +255,8 @@ export default function ToxinaBotulínicaPage() {
                   equilíbrio entre alívio da dor e preservação da função anal.
                 </p>
               </blockquote>
+
+              <RelatedBlogCard treatmentSlug="toxina-botulinica" />
 
               <h2>Perguntas frequentes (FAQ)</h2>
 

--- a/src/components/sections/TreatmentsSection.tsx
+++ b/src/components/sections/TreatmentsSection.tsx
@@ -1,5 +1,6 @@
 import { LinkButton } from '@/components/ui/LinkButton'
 import { TreatmentCard } from '@/components/ui/TreatmentCard'
+import { getTreatmentImageBySlug } from '@/lib/treatment-images'
 
 const treatments = [
   {
@@ -66,15 +67,21 @@ export function TreatmentsSection() {
 
           {/* Smart Responsive Grid - Hides last item for even columns */}
           <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 sm:gap-6 xl:grid-cols-3 xl:gap-7">
-            {treatments.map((treatment, index) => (
-              <TreatmentCard
-                key={treatment.slug}
-                title={treatment.name}
-                href={`/tratamentos/${treatment.slug}`}
-                variant="compact"
-                className={index === treatments.length - 1 ? 'sm:hidden lg:flex' : undefined}
-              />
-            ))}
+            {treatments.map((treatment, index) => {
+              const treatmentImage = getTreatmentImageBySlug(treatment.slug)
+
+              return (
+                <TreatmentCard
+                  key={treatment.slug}
+                  title={treatment.name}
+                  href={`/tratamentos/${treatment.slug}`}
+                  variant="compact"
+                  treatmentId={treatmentImage?.id}
+                  image={treatmentImage}
+                  className={index === treatments.length - 1 ? 'sm:hidden lg:flex' : undefined}
+                />
+              )
+            })}
           </div>
         </div>
 

--- a/src/components/ui/Footer.tsx
+++ b/src/components/ui/Footer.tsx
@@ -10,7 +10,7 @@ import Instagram from '../icons/instagram'
 export function Footer() {
   return (
     <footer className="w-full bg-primary" aria-label="Footer">
-      <div className="max-w-[1760px] mx-auto px-6 sm:px-8 lg:px-10 xl:px-12 py-8 lg:py-12">
+      <div className="max-w-[1760px] mx-auto px-6 sm:px-8 lg:px-10 xl:px-12 pt-8 pb-24 lg:pt-12 lg:pb-20">
         <div className="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-8">
           <div className="flex flex-col gap-y-4">
             <Link

--- a/src/components/ui/RelatedBlogCard.tsx
+++ b/src/components/ui/RelatedBlogCard.tsx
@@ -1,0 +1,37 @@
+import { Badge } from '@/components/ui/Badge'
+import { LinkButton } from '@/components/ui/LinkButton'
+import { getRelatedBlogByTreatmentSlug } from '@/lib/treatment-related-blog'
+
+interface RelatedBlogCardProps {
+  treatmentSlug: string
+}
+
+export function RelatedBlogCard({ treatmentSlug }: RelatedBlogCardProps) {
+  const relatedBlog = getRelatedBlogByTreatmentSlug(treatmentSlug)
+
+  if (!relatedBlog) {
+    return null
+  }
+
+  return (
+    <aside className="not-prose my-10">
+      <div className="rounded-3xl border border-secondary/20 bg-secondary/10 p-6 sm:p-8">
+        <Badge variant="secondary" className="mb-4">
+          Leitura relacionada
+        </Badge>
+        <h3 className="text-xl sm:text-2xl font-serif font-bold text-primary mb-3 leading-tight">
+          {relatedBlog.title}
+        </h3>
+        <p className="text-base text-secondary leading-relaxed mb-6">{relatedBlog.description}</p>
+        <LinkButton
+          href={relatedBlog.href}
+          variant="outline"
+          size="default"
+          className="hover:text-white focus:text-white active:text-white"
+        >
+          Ver artigo no blog
+        </LinkButton>
+      </div>
+    </aside>
+  )
+}

--- a/src/components/ui/TreatmentCard.tsx
+++ b/src/components/ui/TreatmentCard.tsx
@@ -1,6 +1,8 @@
+import Image from 'next/image'
 import Link from 'next/link'
 import { ArrowRight } from 'lucide-react'
 import { Badge } from '@/components/ui/Badge'
+import type { TreatmentImage } from '@/lib/treatment-images'
 import { cn } from '@/lib/utils'
 
 interface TreatmentCardProps {
@@ -9,6 +11,8 @@ interface TreatmentCardProps {
   description?: string
   category?: string
   variant?: 'compact' | 'detailed'
+  treatmentId?: string
+  image?: Pick<TreatmentImage, 'src' | 'alt'>
   className?: string
 }
 
@@ -18,6 +22,8 @@ export function TreatmentCard({
   description,
   category,
   variant = 'compact',
+  treatmentId,
+  image,
   className,
 }: TreatmentCardProps) {
   const isDetailed = variant === 'detailed'
@@ -28,6 +34,7 @@ export function TreatmentCard({
 
   return (
     <div
+      data-treatment-id={treatmentId}
       className={cn(
         'group relative isolate flex items-stretch overflow-hidden rounded-[1.4rem] border border-secondary/20 bg-secondary/10 shadow-sm transition-all duration-200 ease-out hover:-translate-y-[2px] hover:border-primary/35 hover:bg-secondary/15 hover:shadow-md active:translate-y-0 active:shadow-sm focus-within:ring-2 focus-within:ring-primary/65 focus-within:ring-offset-2 focus-within:ring-offset-background',
         isDetailed
@@ -36,6 +43,19 @@ export function TreatmentCard({
         className
       )}
     >
+      {image ? (
+        <div aria-hidden className="absolute inset-0 z-0">
+          <Image
+            src={image.src}
+            alt={image.alt}
+            fill
+            sizes="(min-width: 1280px) 30vw, (min-width: 640px) 45vw, 100vw"
+            className="object-cover opacity-30 transition-opacity duration-300 group-hover:opacity-40"
+          />
+          <div className="absolute inset-0 bg-gradient-to-br from-background/95 via-background/92 to-background/88" />
+        </div>
+      ) : null}
+
       <Link
         href={href}
         aria-label={cardAriaLabel}

--- a/src/components/ui/TreatmentHeroImage.tsx
+++ b/src/components/ui/TreatmentHeroImage.tsx
@@ -1,0 +1,30 @@
+import Image from 'next/image'
+import { getTreatmentImageBySlug } from '@/lib/treatment-images'
+
+interface TreatmentHeroImageProps {
+  slug: string
+}
+
+export function TreatmentHeroImage({ slug }: TreatmentHeroImageProps) {
+  const treatmentImage = getTreatmentImageBySlug(slug)
+
+  if (!treatmentImage) {
+    return null
+  }
+
+  return (
+    <figure
+      data-treatment-id={treatmentImage.id}
+      className="mb-10 overflow-hidden rounded-2xl border border-secondary/20 bg-secondary/10 shadow-sm"
+    >
+      <Image
+        src={treatmentImage.src}
+        alt={treatmentImage.alt}
+        width={1600}
+        height={900}
+        sizes="(min-width: 1280px) 56rem, (min-width: 768px) 80vw, 100vw"
+        className="h-auto w-full object-cover"
+      />
+    </figure>
+  )
+}

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -67,6 +67,14 @@ export interface FAQItem {
 }
 
 /**
+ * Blog card image metadata extracted from markdown body
+ */
+export interface BlogCardImage {
+  src: string
+  alt: string
+}
+
+/**
  * Blog post frontmatter metadata interface
  */
 export interface BlogPostMeta {
@@ -91,6 +99,7 @@ export interface BlogPostMeta {
 export interface BlogPost extends BlogPostMeta {
   content: string
   excerpt: string
+  cardImage?: BlogCardImage
 }
 
 /** Posts directory path */
@@ -196,6 +205,32 @@ function createExcerpt(content: string): string {
 }
 
 /**
+ * Extracts the first markdown image from the post body for card previews
+ * @param content - The markdown content
+ * @returns First image src/alt metadata when available
+ */
+function extractFirstImage(content: string): BlogCardImage | undefined {
+  const markdownImageRegex = /!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/m
+  const match = content.match(markdownImageRegex)
+
+  if (!match) {
+    return undefined
+  }
+
+  const altText = match[1]?.trim() || 'Imagem do artigo'
+  const src = match[2]?.trim().replace(/^<|>$/g, '')
+
+  if (!src) {
+    return undefined
+  }
+
+  return {
+    src,
+    alt: altText,
+  }
+}
+
+/**
  * Get a single blog post by its slug
  * @param slug - The post slug (filename without .md extension)
  * @returns Blog post data or null if not found
@@ -212,12 +247,14 @@ export function getPostBySlug(slug: string): BlogPost | null {
 
     const readingTime = calculateReadingTime(content)
     const excerpt = createExcerpt(content)
+    const cardImage = extractFirstImage(content)
 
     return {
       slug,
       content,
       excerpt,
       readingTime,
+      cardImage,
       ...data,
     } as BlogPost
   } catch (error) {

--- a/src/lib/treatment-images.ts
+++ b/src/lib/treatment-images.ts
@@ -1,0 +1,72 @@
+export const TREATMENT_IMAGE_BY_SLUG = {
+  'cx-laser': {
+    id: 'TRT-001',
+    slug: 'cx-laser',
+    src: '/images/posts/tratamento-fistulas-anorretais/fistula-laser.png',
+    alt: 'Ilustracao de tratamento proctologico com laser',
+    sourcePostSlug: 'tratamento-fistulas-anorretais',
+  },
+  hemorroidas: {
+    id: 'TRT-002',
+    slug: 'hemorroidas',
+    src: '/images/posts/hemorroida-sempre-cirurgica-tratamento/hemorroidas-internas-externas.png',
+    alt: 'Ilustracao comparativa de hemorroidas internas e externas',
+    sourcePostSlug: 'hemorroida-sempre-cirurgica-tratamento',
+  },
+  'cx-fistulas-anorretais': {
+    id: 'TRT-003',
+    slug: 'cx-fistulas-anorretais',
+    src: '/images/posts/tratamento-fistulas-anorretais/fistula.png',
+    alt: 'Ilustracao de fistula anorretal',
+    sourcePostSlug: 'tratamento-fistulas-anorretais',
+  },
+  'toxina-botulinica': {
+    id: 'TRT-004',
+    slug: 'toxina-botulinica',
+    src: '/images/posts/fissura-anal-tratamento/fissura-anal.png',
+    alt: 'Ilustracao de fissura anal para contexto de tratamento',
+    sourcePostSlug: 'fissura-anal-tratamento',
+  },
+  'rastreio-cancer-anal': {
+    id: 'TRT-005',
+    slug: 'rastreio-cancer-anal',
+    src: '/images/posts/cancer-colorretal/polipos-intestinais.png',
+    alt: 'Ilustracao de polipos intestinais e rastreio de cancer',
+    sourcePostSlug: 'cancer-colorretal-rastreio-prevencao-diagnostico-precoce',
+  },
+  'hpv-anal': {
+    id: 'TRT-006',
+    slug: 'hpv-anal',
+    src: '/images/posts/hpv-anal/condilomas-hpv.png',
+    alt: 'Ilustracao de condilomas associados ao HPV anal',
+    sourcePostSlug: 'hpv-anal-condilomas-riscos-tratamento-rastreio',
+  },
+  'cx-cisto-pilonidal': {
+    id: 'TRT-007',
+    slug: 'cx-cisto-pilonidal',
+    src: '/images/posts/cisto-pilonidal-cirurgia-laser-quando-operar/cisto-pilonidal.png',
+    alt: 'Ilustracao anatomica de cisto pilonidal',
+    sourcePostSlug: 'cisto-pilonidal-cirurgia-laser-quando-operar',
+  },
+  'doencas-inflamatorias-intestinais': {
+    id: 'TRT-008',
+    slug: 'doencas-inflamatorias-intestinais',
+    src: '/images/posts/doencas-inflamatorias-intestinais-acompanhamento/doencas-inflamatorias-intestinais.png',
+    alt: 'Ilustracao de doencas inflamatorias intestinais',
+    sourcePostSlug: 'doencas-inflamatorias-intestinais-acompanhamento',
+  },
+  'sindrome-intestino-irritavel': {
+    id: 'TRT-009',
+    slug: 'sindrome-intestino-irritavel',
+    src: '/images/posts/sindrome-intestino-irritavel/sindrome-intestino-irritavel.png',
+    alt: 'Ilustracao sobre sindrome do intestino irritavel',
+    sourcePostSlug: 'sindrome-intestino-irritavel-sintomas-diagnostico-tratamento',
+  },
+} as const
+
+export type TreatmentSlug = keyof typeof TREATMENT_IMAGE_BY_SLUG
+export type TreatmentImage = (typeof TREATMENT_IMAGE_BY_SLUG)[TreatmentSlug]
+
+export function getTreatmentImageBySlug(slug: string): TreatmentImage | undefined {
+  return TREATMENT_IMAGE_BY_SLUG[slug as TreatmentSlug]
+}

--- a/src/lib/treatment-related-blog.ts
+++ b/src/lib/treatment-related-blog.ts
@@ -1,0 +1,68 @@
+import type { TreatmentSlug } from '@/lib/treatment-images'
+
+export interface RelatedBlogEntry {
+  href: string
+  title: string
+  description: string
+}
+
+const RELATED_BLOG_BY_TREATMENT: Record<TreatmentSlug, RelatedBlogEntry> = {
+  'cx-laser': {
+    href: '/blog/cisto-pilonidal-cirurgia-laser-quando-operar',
+    title: 'Cisto pilonidal: quando operar e como o laser pode ajudar',
+    description:
+      'Entenda as indicações, benefícios e limitações da abordagem a laser em um exemplo clínico comum.',
+  },
+  hemorroidas: {
+    href: '/blog/hemorroida-sempre-cirurgica-tratamento',
+    title: 'Hemorroida sempre precisa de cirurgia?',
+    description:
+      'Veja quando o tratamento clínico resolve e em quais casos os procedimentos são considerados.',
+  },
+  'cx-fistulas-anorretais': {
+    href: '/blog/tratamento-fistulas-anorretais',
+    title: 'Tratamento de fístulas anorretais: técnicas e critérios',
+    description:
+      'Comparativo prático das abordagens mais usadas para preservar função e reduzir recidiva.',
+  },
+  'toxina-botulinica': {
+    href: '/blog/fissura-anal-tratamento',
+    title: 'Fissura anal: opções de tratamento e quando escalar cuidado',
+    description:
+      'Guia educativo para entender manejo inicial, falhas de resposta e alternativas terapêuticas.',
+  },
+  'rastreio-cancer-anal': {
+    href: '/blog/hpv-anal-condilomas-riscos-tratamento-rastreio',
+    title: 'HPV anal, rastreio e redução de risco',
+    description:
+      'Conteúdo focado em prevenção, vigilância e sinais que merecem acompanhamento especializado.',
+  },
+  'hpv-anal': {
+    href: '/blog/hpv-anal-condilomas-riscos-tratamento-rastreio',
+    title: 'HPV anal e condilomas: quando investigar e tratar',
+    description:
+      'Entenda opções terapêuticas, acompanhamento e estratégia de rastreio para reduzir complicações.',
+  },
+  'cx-cisto-pilonidal': {
+    href: '/blog/cisto-pilonidal-cirurgia-laser-quando-operar',
+    title: 'Cisto pilonidal: o que muda na cirurgia a laser',
+    description:
+      'Artigo com foco em indicação cirúrgica, recuperação e expectativas realistas de resultado.',
+  },
+  'doencas-inflamatorias-intestinais': {
+    href: '/blog/doencas-inflamatorias-intestinais-acompanhamento',
+    title: 'Doença de Crohn e retocolite: importância do acompanhamento',
+    description:
+      'Por que o seguimento contínuo ajuda no controle dos sintomas e na prevenção de complicações.',
+  },
+  'sindrome-intestino-irritavel': {
+    href: '/blog/sindrome-intestino-irritavel-sintomas-diagnostico-tratamento',
+    title: 'Síndrome do intestino irritável: sinais, diagnóstico e manejo',
+    description:
+      'Resumo objetivo sobre gatilhos, investigação e estratégias para melhorar qualidade de vida.',
+  },
+}
+
+export function getRelatedBlogByTreatmentSlug(slug: string): RelatedBlogEntry | undefined {
+  return RELATED_BLOG_BY_TREATMENT[slug as TreatmentSlug]
+}


### PR DESCRIPTION
## Summary
- add a shared treatment-image map and render image-backed treatment cards in `/tratamentos` and homepage treatment sections
- add `TreatmentHeroImage` and `RelatedBlogCard` to each treatment detail page to improve internal linking to relevant blog posts
- extract first markdown image in `src/lib/blog.ts` and use it on `/blog` cards with updated card layout
- update SEO keyword tracking assets (`docs/seo-keywords-tracking.md`, `docs/seo-keywords-tracking.csv`, `docs/serp-keywords-tracking.csv`)
- adjust footer bottom spacing to avoid overlap with sticky UI controls

## Verification
- `npm run build`

## Notes
- branch: `codex/2026-03-10-treatment-blog-linking`
- all current local changes were included in this draft PR commit as requested