### PR TITLE
[codex] add location pages and physician location schema

### DIFF
--- a/content/posts/cisto-pilonidal-cisto-sacrococcigeo-mesma-coisa.md
+++ b/content/posts/cisto-pilonidal-cisto-sacrococcigeo-mesma-coisa.md
@@ -1,0 +1,125 @@
+---
+title: 'Cisto pilonidal e cisto sacrococcígeo são a mesma coisa?'
+metaDescription: 'Cisto pilonidal e cisto sacrococcígeo são a mesma coisa? Entenda os termos, sintomas e quando a avaliação cirúrgica é indicada em Curitiba.'
+slug: 'cisto-pilonidal-cisto-sacrococcigeo-mesma-coisa'
+publishDate: '2026-04-02'
+lastModified: '2026-04-02'
+primaryKeyword: 'cisto pilonidal e cisto sacrococcígeo'
+secondaryKeywords:
+  - 'cisto sacrococcigeo curitiba'
+  - 'cisto pilonidal curitiba'
+  - 'cirurgia coccix curitiba'
+  - 'cisto pilonidal cirurgia'
+  - 'proctologista curitiba'
+targetAudience: 'patients'
+intent: 'awareness'
+featured: false
+order: 35
+relatedTreatments:
+  - 'cx-cisto-pilonidal'
+  - 'cx-laser'
+relatedPosts:
+  - 'cisto-pilonidal-cirurgia-laser-quando-operar'
+  - 'cisto-pilonidal-precisa-cirurgia'
+faqs:
+  - question: 'Cisto pilonidal e cisto sacrococcígeo são termos diferentes para o mesmo problema?'
+    answer: 'Na prática, sim. Ambos costumam se referir à mesma condição na região próxima ao cóccix.'
+  - question: 'Todo cisto pilonidal precisa de cirurgia?'
+    answer: 'Nem sempre no mesmo momento, mas casos recorrentes, com inflamação ou drenagem persistente costumam exigir avaliação cirúrgica.'
+  - question: 'Laser pode ser usado em todos os casos?'
+    answer: 'Não. O uso do laser depende da anatomia da lesão, do histórico e do objetivo do tratamento.'
+  - question: 'Abscesso sacrococcígeo é a mesma coisa que cisto pilonidal?'
+    answer: 'O abscesso pode ser uma manifestação inflamada do cisto pilonidal, mas nem todo quadro inflamatório significa o mesmo estágio da doença.'
+---
+
+_Os nomes mudam de um exame para outro, mas a dúvida do paciente costuma ser a mesma: afinal, cisto pilonidal e cisto sacrococcígeo são o mesmo problema?_
+
+Em muitos laudos, buscas no Google ou conversas do dia a dia, aparecem termos como:
+
+- cisto pilonidal,
+- cisto sacrococcígeo,
+- abscesso sacrococcígeo,
+- cisto no cóccix.
+
+Na prática, eles costumam apontar para a mesma região anatômica e para um problema muito semelhante: um processo inflamatório localizado próximo ao sulco interglúteo, na área do cóccix.
+
+## Então os nomes são equivalentes?
+
+Na maior parte dos casos, sim.
+**Cisto pilonidal** é o termo mais usado na rotina médica.
+**Cisto sacrococcígeo** descreve a localização anatômica da lesão.
+
+Dependendo do estágio do quadro, o paciente também pode ouvir expressões como:
+
+- inflamação pilonidal,
+- abscesso pilonidal,
+- doença pilonidal.
+
+O mais importante é entender se existe:
+
+- inflamação ativa,
+- saída de secreção,
+- episódios recorrentes,
+- necessidade de drenagem,
+- indicação de cirurgia definitiva.
+
+## Quais sintomas costumam aparecer?
+
+Os sinais mais comuns incluem:
+
+- dor na região do cóccix,
+- nódulo ou inchaço local,
+- saída de secreção,
+- vermelhidão,
+- episódios repetidos de inflamação.
+
+Em fases mais agudas, pode surgir um **abscesso**, com dor mais intensa e limitação para sentar.
+
+## Quando é só uma inflamação e quando precisa pensar em cirurgia?
+
+Nem todo paciente precisa operar imediatamente.
+Mas alguns cenários merecem atenção:
+
+- crises repetidas,
+- secreção persistente,
+- múltiplos orifícios na linha média,
+- limitação funcional,
+- histórico de drenagem prévia sem resolução definitiva.
+
+Se você quer entender melhor esse momento de decisão, vale complementar com [cisto pilonidal: precisa de cirurgia?](/blog/cisto-pilonidal-precisa-cirurgia).
+
+## O laser entra em quais casos?
+
+O laser pode ser considerado em **casos selecionados**, com avaliação individualizada da anatomia e do histórico.
+Ele não substitui automaticamente outras técnicas, mas pode ser útil quando o objetivo é tratar a doença com menor trauma cirúrgico em contextos adequados.
+
+Para aprofundar esse ponto, a página sobre [cirurgia de cisto pilonidal](/tratamentos/cx-cisto-pilonidal) ajuda a organizar as opções disponíveis.
+Se o interesse é especificamente na abordagem a laser, também vale ver [quando o laser pode ajudar no cisto pilonidal](/tratamentos/cx-laser) e o artigo [cisto pilonidal: quando operar e como o laser pode ajudar](/blog/cisto-pilonidal-cirurgia-laser-quando-operar).
+
+## O que muda quando o quadro fica recorrente?
+
+Quando a inflamação volta várias vezes, o tratamento costuma deixar de ser apenas episódico.
+O objetivo passa a ser:
+
+- reduzir novas crises,
+- diminuir dor e secreção,
+- tratar a doença de forma mais definitiva,
+- orientar cuidados no pós-operatório.
+
+É justamente nessas situações que a avaliação com especialista ajuda a diferenciar medidas temporárias de um plano mais resolutivo.
+
+## Conclusão
+
+Na rotina prática, **cisto pilonidal** e **cisto sacrococcígeo** costumam se referir à mesma condição, localizada na região do cóccix.
+O que realmente muda a conduta não é o nome usado, mas o estágio da doença, a frequência das crises e o impacto na vida do paciente.
+
+Quando há dor recorrente, secreção ou inflamações repetidas, vale procurar avaliação para definir se o caso pede observação, drenagem momentânea ou cirurgia planejada.
+
+---
+
+**Dra. Ana Luiza Moraes Rocha**  
+Médica Coloproctologista  
+CRM-PR 45351 | RQE 36221  
+Especialista em Coloproctologia
+
+> _Este conteúdo tem caráter educativo e não substitui a consulta médica. Procure sempre orientação profissional para diagnóstico e tratamento adequados._

--- a/content/posts/doencas-inflamatorias-intestinais-acompanhamento.md
+++ b/content/posts/doencas-inflamatorias-intestinais-acompanhamento.md
@@ -1,9 +1,9 @@
 ---
 title: 'Doenças inflamatórias intestinais (DII): acompanhamento especializado'
-metaDescription: 'Saiba como funciona o acompanhamento da Doença de Crohn e Retocolite Ulcerativa com monitoramento contínuo, prevenção de complicações e tratamento individualizado.'
+metaDescription: 'Saiba como funciona o acompanhamento da Doença de Crohn e Retocolite Ulcerativa com monitoramento contínuo, prevenção de complicações e tratamento individualizado em Curitiba.'
 slug: 'doencas-inflamatorias-intestinais-acompanhamento'
 publishDate: '2026-03-07'
-lastModified: '2026-03-07'
+lastModified: '2026-04-02'
 primaryKeyword: 'doenças inflamatórias intestinais'
 secondaryKeywords:
   - 'Doença de Crohn'
@@ -11,10 +11,17 @@ secondaryKeywords:
   - 'acompanhamento DII'
   - 'tratamento DII'
   - 'coloproctologista Curitiba'
+  - 'tratamento crohn curitiba'
+  - 'proctologista curitiba'
 targetAudience: 'patients'
 intent: 'consideration'
 featured: false
 order: 18
+relatedTreatments:
+  - 'doencas-inflamatorias-intestinais'
+relatedPosts:
+  - 'diarreia-cronica-tratamento'
+  - 'sangue-nas-fezes-quando-procurar-coloproctologista'
 faqs:
   - question: 'Doença de Crohn e Retocolite Ulcerativa têm cura?'
     answer: 'São doenças crônicas. O objetivo é controlar a inflamação, manter remissão e prevenir complicações com acompanhamento regular.'
@@ -33,6 +40,8 @@ As Doenças Inflamatórias Intestinais (DII), como a Doença de Crohn e a Retoco
 Não se trata apenas de controlar sintomas, mas de prevenir complicações, preservar qualidade de vida e reduzir impacto a longo prazo.
 
 A Dra. Ana Luiza, coloproctologista em Curitiba, oferece acompanhamento especializado em Doenças Inflamatórias Intestinais com abordagem integrada e foco em cuidado contínuo.
+
+Se você quiser ver como esse acompanhamento aparece na página de atendimento, vale acessar [Doença de Crohn e retocolite](/tratamentos/doencas-inflamatorias-intestinais).
 
 ![Visão geral das doenças inflamatórias intestinais](/images/posts/doencas-inflamatorias-intestinais-acompanhamento/doencas-inflamatorias-intestinais.webp)
 
@@ -65,6 +74,8 @@ Ambas podem apresentar períodos de atividade e remissão.
 ![Principais manifestações clínicas da Doença de Crohn e da Retocolite Ulcerativa](/images/posts/doencas-inflamatorias-intestinais-acompanhamento/chron-retite-ulcerativa.webp)
 
 O diagnóstico precoce é fundamental para evitar complicações.
+
+Quando diarreia persistente, sangue nas fezes ou perda de peso são os primeiros sinais, estes dois conteúdos podem complementar a leitura: [diarreia crônica: causas, diagnóstico e tratamentos](/blog/diarreia-cronica-tratamento) e [sangue nas fezes: quando se preocupar](/blog/sangue-nas-fezes-quando-procurar-coloproctologista).
 
 ## Avaliação e monitoramento contínuo
 

--- a/content/posts/fissura-anal-toxina-botulinica-tratamento.md
+++ b/content/posts/fissura-anal-toxina-botulinica-tratamento.md
@@ -1,9 +1,9 @@
 ---
 title: 'Fissura anal: toxina botulínica ajuda mesmo?'
-metaDescription: 'Saiba como a toxina botulínica (botox) atua no tratamento da fissura anal crônica, quando é indicada e quais são os benefícios. Coloproctologista em Curitiba.'
+metaDescription: 'Saiba como a toxina botulínica (botox) atua no tratamento da fissura anal crônica, quando é indicada e quais são os benefícios com proctologista em Curitiba.'
 slug: 'fissura-anal-toxina-botulinica-tratamento'
 publishDate: '2026-03-15'
-lastModified: '2026-03-15'
+lastModified: '2026-04-02'
 primaryKeyword: 'toxina botulínica fissura anal'
 secondaryKeywords:
   - 'botox fissura anal'
@@ -11,11 +11,18 @@ secondaryKeywords:
   - 'toxina botulínica coloproctologia'
   - 'fissura anal sem cirurgia'
   - 'coloproctologista Curitiba'
+  - 'proctologista curitiba'
   - 'esfíncter anal relaxamento'
 targetAudience: 'patients'
 intent: 'consideration'
 featured: false
 order: 24
+relatedTreatments:
+  - 'toxina-botulinica'
+  - 'cx-laser'
+relatedPosts:
+  - 'fissura-anal-tratamento'
+  - 'fissura-anal-quando-cirurgia-indicada'
 faqs:
   - question: 'Botox para fissura dói?'
     answer: 'O procedimento costuma ser bem tolerado, mas geralmente realizado com anestésico local.'
@@ -35,6 +42,8 @@ Muitos pacientes perguntam:
 "Botox realmente funciona para fissura?"
 
 A resposta é: em muitos casos, sim.
+
+Quando a dor ao evacuar persiste e a fissura se torna crônica, a avaliação com **proctologista ou coloproctologista** ajuda a definir se o caso ainda responde a medidas clínicas ou se vale considerar opções como a [toxina botulínica para fissura anal](/tratamentos/toxina-botulinica).
 
 ## Como funciona a toxina botulínica?
 
@@ -56,6 +65,8 @@ A aplicação costuma ser considerada quando:
 - o tratamento clínico não foi suficiente
 - existe espasmo muscular importante
 
+Antes de indicar o procedimento, também vale revisar a base do tratamento da fissura, tema explicado em [fissura anal: sintomas, tratamentos e como a coloproctologia pode ajudar](/blog/fissura-anal-tratamento).
+
 ## Vantagens do tratamento
 
 Entre os benefícios estão:
@@ -70,6 +81,8 @@ Entre os benefícios estão:
 Em alguns pacientes, a fissura cicatriza completamente.
 
 Em outros, pode ser necessário repetir o tratamento ou considerar cirurgia.
+
+Quando a resposta não é suficiente ou a fissura já apresenta critérios de cronicidade mais marcados, o próximo passo pode incluir revisão de outras estratégias. Para esse cenário, o artigo [fissura anal: quando a cirurgia está indicada?](/blog/fissura-anal-quando-cirurgia-indicada) complementa bem a leitura.
 
 ## Perguntas frequentes (FAQ)
 

--- a/content/posts/hpv-anal-condilomas-riscos-tratamento-rastreio.md
+++ b/content/posts/hpv-anal-condilomas-riscos-tratamento-rastreio.md
@@ -1,9 +1,9 @@
 ---
 title: 'HPV anal e condilomas: o que são, riscos, tratamento e importância do rastreio'
-metaDescription: 'Entenda HPV anal e condilomas: sintomas, riscos, tratamento, vacina e rastreio para prevenção do câncer anal com coloproctologista em Curitiba.'
+metaDescription: 'Entenda HPV anal e condilomas: sintomas, riscos, tratamento, vacina e rastreio para prevenção do câncer anal com proctologista em Curitiba.'
 slug: 'hpv-anal-condilomas-riscos-tratamento-rastreio'
 publishDate: '2026-02-20'
-lastModified: '2026-02-20'
+lastModified: '2026-04-02'
 primaryKeyword: 'HPV anal'
 secondaryKeywords:
   - 'condilomas anais'
@@ -11,10 +11,18 @@ secondaryKeywords:
   - 'cancer anal HPV'
   - 'vacina HPV adultos'
   - 'coloproctologista Curitiba'
+  - 'verrugas anais curitiba'
+  - 'proctologista curitiba'
 targetAudience: 'patients'
 intent: 'awareness'
 featured: false
 order: 12
+relatedTreatments:
+  - 'hpv-anal'
+  - 'rastreio-cancer-anal'
+relatedPosts:
+  - 'cancer-canal-anal-rastreio-hpv-quem-deve-se-preocupar'
+  - 'proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento'
 faqs:
   - question: 'HPV anal sempre causa verrugas?'
     answer: 'Não. Muitas infecções são assintomáticas e só são identificadas em exames de rastreio.'
@@ -37,6 +45,8 @@ Essas perguntas são muito comuns no consultório.
 A infecção por **HPV anal** e o aparecimento de **condilomas (verrugas anais)** ainda são cercados de desinformação e estigma. Quando bem acompanhada, porém, é uma condição **tratável, rastreável e prevenível**.
 
 Neste artigo, a **Dra. Ana Luiza**, coloproctologista em Curitiba, explica o que é o HPV anal, sua história natural, os riscos associados, as opções de tratamento, a importância da vacina e do rastreio adequado.
+
+Para ver como esses temas aparecem organizados nas páginas de atendimento, você também pode revisar [tratamento de HPV anal](/tratamentos/hpv-anal) e [rastreio de câncer anal e HPV](/tratamentos/rastreio-cancer-anal).
 
 ![Ilustração de condilomas anais associados ao HPV](/images/posts/hpv-anal/condilomas-hpv.webp)
 
@@ -115,6 +125,8 @@ Semelhante ao exame preventivo ginecológico, avalia alterações celulares.
 Permite visualização detalhada da mucosa anal e identificação de lesões suspeitas, com possibilidade de biópsia.
 
 O rastreio é indicado principalmente para pacientes com fatores de risco, mas deve ser individualizado.
+
+Se a principal dúvida hoje é quem realmente deve investigar e com que urgência, vale complementar esta leitura com [câncer de canal anal: rastreio, HPV e quem deve se preocupar](/blog/cancer-canal-anal-rastreio-hpv-quem-deve-se-preocupar).
 
 ## Tratamento dos condilomas anais
 

--- a/content/posts/ligadura-elastica-hemorroidas-doi-recuperacao.md
+++ b/content/posts/ligadura-elastica-hemorroidas-doi-recuperacao.md
@@ -1,0 +1,136 @@
+---
+title: 'Ligadura elástica para hemorroidas dói? Quando é indicada e como é a recuperação'
+metaDescription: 'Ligadura elástica para hemorroidas dói? Entenda quando é indicada, como funciona e o que esperar da recuperação com proctologista em Curitiba.'
+slug: 'ligadura-elastica-hemorroidas-doi-recuperacao'
+publishDate: '2026-04-02'
+lastModified: '2026-04-02'
+primaryKeyword: 'ligadura elástica para hemorroidas dói'
+secondaryKeywords:
+  - 'ligadura elástica curitiba'
+  - 'ligadura elástica hemorroida'
+  - 'tratamento hemorroidas curitiba'
+  - 'hemorroidas internas'
+  - 'proctologista curitiba'
+targetAudience: 'patients'
+intent: 'consideration'
+featured: false
+order: 33
+relatedTreatments:
+  - 'hemorroidas'
+relatedPosts:
+  - 'hemorroida-sempre-cirurgica-tratamento'
+  - 'thd-hemorroidas-quando-indicado'
+faqs:
+  - question: 'A ligadura elástica dói muito?'
+    answer: 'Ela pode causar pressão ou desconforto leve nos primeiros dias, mas geralmente é bem tolerada quando a indicação é correta.'
+  - question: 'Para quais hemorroidas a ligadura elástica costuma ser indicada?'
+    answer: 'Principalmente para hemorroidas internas de graus II e III em casos selecionados.'
+  - question: 'Precisa de internação?'
+    answer: 'Em geral, não. A ligadura elástica costuma ser feita em ambiente ambulatorial.'
+  - question: 'A hemorroida pode voltar depois?'
+    answer: 'Pode haver recorrência, especialmente se persistirem fatores como constipação, esforço evacuatório e hábitos intestinais inadequados.'
+---
+
+_A ligadura elástica costuma ser lembrada como um tratamento rápido para hemorroidas internas, mas entender a indicação certa faz diferença no conforto e no resultado._
+
+Muitos pacientes chegam à consulta com uma dúvida objetiva:
+"A ligadura elástica dói?"
+
+A resposta mais honesta é que ela pode causar **desconforto**, mas, quando bem indicada, costuma ser um procedimento **rápido, ambulatorial e bem tolerado**.
+
+## O que é a ligadura elástica?
+
+Trata-se de um procedimento usado principalmente para **hemorroidas internas**.
+Uma pequena borracha é posicionada na base do mamilo hemorroidário para interromper o fluxo sanguíneo local.
+
+Com isso:
+
+- o tecido tratado sofre redução progressiva,
+- o sangramento tende a melhorar,
+- e o prolapso pode diminuir.
+
+Se você quer uma visão geral das opções terapêuticas, a página de [tratamento de hemorroidas](/tratamentos/hemorroidas) reúne as principais abordagens usadas na prática.
+
+## Quando a ligadura elástica costuma ser indicada?
+
+Ela costuma ser considerada principalmente em:
+
+- hemorroidas internas de **grau II**,
+- alguns casos de **grau III**,
+- pacientes com sangramento recorrente,
+- quadros em que ainda não há necessidade clara de cirurgia maior.
+
+Em compensação, ela **não é a solução ideal para todo paciente**.
+Hemorroidas externas volumosas, trombose aguda, dor anal importante por outra causa ou combinação de diferentes componentes da doença podem exigir outra estratégia.
+
+## Afinal, dói?
+
+Na maioria das vezes, o que o paciente sente é:
+
+- pressão,
+- desconforto,
+- vontade de evacuar,
+- incômodo nos primeiros dias.
+
+Dor intensa não é o esperado.
+Quando isso acontece, é importante reavaliar, porque pode haver necessidade de ajuste de conduta.
+
+O desconforto costuma ser mais manejável quando:
+
+- a indicação foi correta,
+- o número de áreas tratadas foi adequado,
+- o paciente recebe orientação clara para o pós-procedimento.
+
+## Como costuma ser a recuperação?
+
+Por ser um procedimento ambulatorial, a recuperação tende a ser mais simples do que a de uma cirurgia formal.
+
+Em geral, o paciente é orientado a:
+
+- manter hidratação adequada,
+- evitar esforço evacuatório,
+- usar fibras quando indicado,
+- observar sinais fora do esperado, como dor importante ou sangramento em excesso.
+
+Em muitos casos, o retorno às atividades ocorre de forma relativamente rápida.
+Ainda assim, a evolução depende do grau das hemorroidas, do hábito intestinal e da presença de outras queixas associadas.
+
+## Quando a ligadura elástica pode não ser suficiente?
+
+Existem situações em que a ligadura elástica ajuda, mas não resolve totalmente.
+Isso pode acontecer quando:
+
+- há prolapso mais importante,
+- a doença é mais avançada,
+- coexistem componentes externos significativos,
+- há recidiva frequente.
+
+Nesses cenários, o tratamento pode migrar para outras opções, incluindo cirurgia convencional, cirurgia a laser ou técnicas como THD, dependendo do perfil do caso.
+Se esse é o seu contexto, vale complementar a leitura com [hemorroida é sempre cirúrgica?](/blog/hemorroida-sempre-cirurgica-tratamento) e também com [THD para hemorroidas: quando pode ser indicado](/blog/thd-hemorroidas-quando-indicado).
+
+## O que conversar com o proctologista antes de decidir?
+
+Algumas perguntas úteis são:
+
+- minhas hemorroidas são internas, externas ou mistas?
+- quantas sessões podem ser necessárias?
+- o meu quadro tem melhor perfil para ligadura, cirurgia ou outra técnica?
+- como prevenir recorrência depois do procedimento?
+
+Esse alinhamento evita expectativa irreal e ajuda a escolher a abordagem mais adequada para o seu caso.
+
+## Conclusão
+
+A ligadura elástica pode ser uma ótima opção para **hemorroidas internas selecionadas**, com recuperação relativamente rápida e menor agressividade do que uma cirurgia maior.
+Mas ela funciona melhor quando é indicada com critério e inserida dentro de um plano completo de cuidado intestinal.
+
+Em vez de pensar apenas se o procedimento "dói ou não dói", vale entender se ele realmente é a melhor opção para o tipo de hemorroida presente.
+
+---
+
+**Dra. Ana Luiza Moraes Rocha**  
+Médica Coloproctologista  
+CRM-PR 45351 | RQE 36221  
+Especialista em Coloproctologia
+
+> _Este conteúdo tem caráter educativo e não substitui a consulta médica. Procure sempre orientação profissional para diagnóstico e tratamento adequados._

--- a/content/posts/primeira-consulta-proctologista-curitiba-o-que-esperar.md
+++ b/content/posts/primeira-consulta-proctologista-curitiba-o-que-esperar.md
@@ -1,0 +1,127 @@
+---
+title: 'Primeira consulta com proctologista em Curitiba: o que esperar?'
+metaDescription: 'Saiba como costuma funcionar a primeira consulta com proctologista em Curitiba, o que levar e quando o exame pode ser indicado.'
+slug: 'primeira-consulta-proctologista-curitiba-o-que-esperar'
+publishDate: '2026-04-02'
+lastModified: '2026-04-02'
+primaryKeyword: 'primeira consulta proctologista curitiba'
+secondaryKeywords:
+  - 'consulta com coloproctologista'
+  - 'proctologista curitiba'
+  - 'agendar consulta coloproctologista curitiba'
+  - 'o que levar para consulta proctologista'
+  - 'proctologista e coloproctologista'
+targetAudience: 'patients'
+intent: 'decision'
+featured: false
+order: 36
+relatedTreatments:
+  - 'hemorroidas'
+  - 'sindrome-intestino-irritavel'
+relatedPosts:
+  - 'proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento'
+  - 'quando-procurar-coloproctologista-curitiba'
+faqs:
+  - question: 'Precisa fazer exame já na primeira consulta?'
+    answer: 'Nem sempre. A necessidade de exame depende da queixa, da história clínica e do que for discutido durante a avaliação.'
+  - question: 'O exame com proctologista costuma doer?'
+    answer: 'Muitos exames causam apenas desconforto leve. Quando há dor importante, a conduta precisa ser adaptada ao quadro e ao limite do paciente.'
+  - question: 'O que vale levar para a consulta?'
+    answer: 'Exames prévios, lista de medicamentos, histórico de sintomas e anotações sobre frequência evacuatória, dor ou sangramento ajudam bastante.'
+  - question: 'Posso falar sobre vergonha, medo ou dúvidas mais íntimas?'
+    answer: 'Sim. Esses temas fazem parte da consulta e ajudam a orientar melhor a investigação e o tratamento.'
+---
+
+_A primeira consulta com proctologista não precisa ser cercada de medo: ela começa com escuta, contexto clínico e decisão compartilhada sobre os próximos passos._
+
+Muita gente adia a consulta porque imagina que o atendimento será constrangedor ou que um exame será obrigatório logo no primeiro contato.
+Na prática, a avaliação costuma ser mais organizada, gradual e respeitosa do que o paciente imagina.
+
+Se você está pensando em marcar uma consulta com proctologista em Curitiba, entender como esse encontro costuma acontecer ajuda a chegar mais preparado e menos ansioso.
+
+## O que vale levar para a consulta?
+
+Se tiver disponível, pode ser útil levar:
+
+- exames prévios,
+- receitas e lista de medicações em uso,
+- histórico de cirurgias e doenças,
+- datas aproximadas de início dos sintomas,
+- informações sobre sangramento, dor, constipação ou diarreia.
+
+Esses detalhes ajudam a diferenciar uma queixa episódica de um quadro que já merece investigação mais aprofundada.
+
+## Como a conversa inicial costuma acontecer?
+
+A primeira parte da consulta costuma focar em entender:
+
+- qual é o sintoma principal,
+- quando ele começou,
+- se há piora ao evacuar,
+- se existe sangramento, secreção ou lesões,
+- como funciona o hábito intestinal,
+- quais tratamentos já foram tentados.
+
+Dependendo da história, o raciocínio pode seguir para temas como hemorroidas, fissura anal, sintomas intestinais funcionais, HPV anal ou doenças inflamatórias intestinais.
+
+## O exame é sempre necessário?
+
+Nem sempre.
+Isso depende da queixa, da segurança do paciente e do que a história clínica sugere.
+
+Em alguns casos, a conversa inicial já permite organizar os próximos passos com clareza.
+Em outros, o exame físico ajuda a confirmar hipóteses e direcionar melhor o tratamento.
+
+Quando o exame é indicado, ele deve ser explicado com antecedência e conduzido com respeito ao conforto do paciente.
+
+## Quais queixas costumam aparecer na primeira consulta?
+
+Algumas das mais frequentes são:
+
+- dor ao evacuar,
+- sangramento anal,
+- coceira persistente,
+- sensação de caroço ou lesão,
+- alteração do hábito intestinal,
+- constipação de longa data,
+- diarreia recorrente.
+
+Se a principal suspeita for hemorroida, pode valer revisar a página sobre [tratamento de hemorroidas](/tratamentos/hemorroidas).
+Quando o problema gira em torno de fissura anal crônica e dor intensa, a página de [toxina botulínica para fissura anal](/tratamentos/toxina-botulinica) ajuda a entender uma das opções terapêuticas consideradas em casos selecionados.
+
+## E se eu estiver com vergonha?
+
+Vergonha, medo do exame e receio de julgamento são extremamente comuns.
+Isso não é sinal de exagero.
+Faz parte do contexto de sintomas íntimos e de um tema que ainda carrega muito tabu.
+
+Se esse é o seu caso, vale complementar a leitura com [proctologista e coloproctologista: qual a diferença?](/blog/proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento) e também com [quando procurar um coloproctologista](/blog/quando-procurar-coloproctologista-curitiba).
+
+## Quando a consulta deve ser antecipada?
+
+Em vez de esperar meses, vale procurar atendimento mais cedo quando houver:
+
+- sangue nas fezes,
+- dor anal intensa,
+- secreção persistente,
+- perda de peso inexplicada,
+- diarreia crônica,
+- sintomas que não melhoram com medidas simples.
+
+Quanto mais claro estiver o quadro, mais cedo é possível definir investigação, tratamento e acompanhamento.
+
+## Conclusão
+
+A primeira consulta com proctologista costuma ser um momento de escuta, organização do raciocínio clínico e esclarecimento de dúvidas.
+Nem todo paciente precisa fazer exame imediatamente, e a avaliação deve sempre ser conduzida com cuidado e respeito.
+
+Chegar preparado ajuda, mas o principal é não adiar sinais que já estão interferindo na sua rotina ou trazendo preocupação.
+
+---
+
+**Dra. Ana Luiza Moraes Rocha**  
+Médica Coloproctologista  
+CRM-PR 45351 | RQE 36221  
+Especialista em Coloproctologia
+
+> _Este conteúdo tem caráter educativo e não substitui a consulta médica. Procure sempre orientação profissional para diagnóstico e tratamento adequados._

--- a/content/posts/proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento.md
+++ b/content/posts/proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento.md
@@ -1,0 +1,130 @@
+---
+title: 'Proctologista e coloproctologista: qual a diferença e quando procurar atendimento?'
+metaDescription: 'Entenda a diferença entre proctologista e coloproctologista, quais sintomas merecem avaliação e quando marcar consulta em Curitiba.'
+slug: 'proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento'
+publishDate: '2026-04-02'
+lastModified: '2026-04-02'
+primaryKeyword: 'proctologista e coloproctologista'
+secondaryKeywords:
+  - 'proctologista curitiba'
+  - 'coloproctologista curitiba'
+  - 'proctologia'
+  - 'quando procurar proctologista'
+  - 'consulta com coloproctologista'
+targetAudience: 'patients'
+intent: 'awareness'
+featured: false
+order: 32
+relatedTreatments:
+  - 'hemorroidas'
+  - 'sindrome-intestino-irritavel'
+relatedPosts:
+  - 'quando-procurar-coloproctologista-curitiba'
+  - 'primeira-consulta-proctologista-curitiba-o-que-esperar'
+faqs:
+  - question: 'Proctologista e coloproctologista são a mesma coisa?'
+    answer: 'Na prática, os dois termos costumam ser usados para a mesma área. Coloproctologia é o nome mais preciso da especialidade médica.'
+  - question: 'Quando devo procurar um proctologista?'
+    answer: 'Quando há sintomas como sangramento anal, dor ao evacuar, coceira persistente, alteração do hábito intestinal, lesões anais ou desconforto intestinal recorrente.'
+  - question: 'O proctologista trata apenas doenças do ânus?'
+    answer: 'Não. A coloproctologia também acompanha condições do reto, cólon e intestino, como constipação, diarreia crônica, síndrome do intestino irritável e doenças inflamatórias intestinais.'
+  - question: 'Toda consulta com proctologista inclui exame?'
+    answer: 'Nem sempre. A necessidade de exame físico depende da queixa, do contexto clínico e da conversa com o paciente durante a avaliação.'
+---
+
+_Os termos “proctologista” e “coloproctologista” costumam gerar dúvida, mas o mais importante é reconhecer os sintomas e procurar avaliação no momento certo._
+
+Quem procura no Google por **proctologista** muitas vezes encontra também o termo **coloproctologista**.
+Isso pode passar a impressão de que se tratam de profissionais diferentes, quando, na prática, o foco é o mesmo: avaliar doenças do intestino, reto e ânus com critério técnico e cuidado individualizado.
+
+Se você tem sintomas como dor anal, sangramento, alteração do hábito intestinal ou lesões na região anal, vale entender como essa especialidade atua e quando faz sentido marcar consulta.
+
+## Proctologista e coloproctologista: existe diferença?
+
+Hoje, o termo **coloproctologista** é o mais preciso para descrever a especialidade.
+Ele reflete o cuidado com:
+
+- ânus e canal anal,
+- reto,
+- cólon,
+- e parte das queixas intestinais que exigem avaliação especializada.
+
+Já o termo **proctologista** continua muito usado no dia a dia e nas buscas dos pacientes.
+Por isso, quando alguém procura um proctologista em Curitiba, geralmente está buscando o mesmo tipo de atendimento oferecido pela coloproctologia.
+
+## Quais sintomas costumam levar o paciente ao consultório?
+
+Alguns exemplos frequentes são:
+
+- sangramento ao evacuar,
+- dor anal ou dor ao evacuar,
+- coceira anal persistente,
+- saída de secreção na região anal,
+- alteração do hábito intestinal,
+- constipação de longa data,
+- diarreia recorrente,
+- sensação de evacuação incompleta,
+- verrugas, nódulos ou lesões anais.
+
+Dependendo da queixa, a investigação pode seguir caminhos diferentes.
+Em casos de **hemorroidas**, por exemplo, pode fazer sentido revisar a página sobre [tratamento de hemorroidas](/tratamentos/hemorroidas).
+Quando o problema principal é **dor intensa com fissura anal**, pode ser útil entender opções como a [toxina botulínica para fissura anal](/tratamentos/toxina-botulinica).
+
+## O que um proctologista também acompanha além das doenças anais?
+
+A especialidade não se restringe às doenças orificiais.
+Ela também pode participar da avaliação e do acompanhamento de quadros como:
+
+- **síndrome do intestino irritável**,
+- constipação intestinal crônica,
+- diarreia persistente,
+- **Doença de Crohn e retocolite ulcerativa**,
+- rastreio de lesões associadas ao HPV e câncer anal,
+- necessidade de integração com colonoscopia e outros exames.
+
+Se a queixa principal é dor abdominal, distensão, constipação ou alternância do ritmo intestinal, a página sobre [síndrome do intestino irritável](/tratamentos/sindrome-intestino-irritavel) pode ajudar a entender quando a investigação especializada é indicada.
+
+## Quando vale marcar consulta sem adiar?
+
+Algumas situações merecem atenção mais precoce:
+
+- sangue nas fezes, mesmo em pequena quantidade,
+- dor anal forte e persistente,
+- recorrência de abscessos ou secreção anal,
+- emagrecimento sem causa aparente,
+- diarreia crônica,
+- lesões anais novas,
+- história pessoal de doença inflamatória intestinal,
+- sintomas intestinais que não melhoram com medidas simples.
+
+Se você quiser uma visão mais ampla sobre sinais de alerta, este conteúdo complementa a leitura: [quando procurar um coloproctologista](/blog/quando-procurar-coloproctologista-curitiba).
+
+## E a primeira consulta, como costuma funcionar?
+
+A avaliação começa pela história clínica.
+O objetivo é entender:
+
+- como os sintomas começaram,
+- o que piora ou melhora,
+- se há sangramento, dor, secreção ou alteração intestinal,
+- histórico de cirurgias, exames e tratamentos prévios,
+- condições clínicas associadas.
+
+Dependendo do caso, o exame físico pode ser indicado, mas isso é sempre contextualizado e conversado com o paciente.
+Se você quer se preparar melhor para esse momento, vale seguir para o artigo [primeira consulta com proctologista em Curitiba: o que esperar](/blog/primeira-consulta-proctologista-curitiba-o-que-esperar).
+
+## Conclusão
+
+Na prática, **proctologista** e **coloproctologista** costumam apontar para o mesmo cuidado especializado.
+Mais importante do que o nome usado na busca é reconhecer sintomas que merecem avaliação e procurar atendimento antes que o quadro se torne mais arrastado ou complexo.
+
+Quando há sinais anais ou intestinais persistentes, a consulta permite organizar a investigação, esclarecer medos e definir com mais segurança o próximo passo.
+
+---
+
+**Dra. Ana Luiza Moraes Rocha**  
+Médica Coloproctologista  
+CRM-PR 45351 | RQE 36221  
+Especialista em Coloproctologia
+
+> _Este conteúdo tem caráter educativo e não substitui a consulta médica. Procure sempre orientação profissional para diagnóstico e tratamento adequados._

--- a/content/posts/thd-hemorroidas-quando-indicado.md
+++ b/content/posts/thd-hemorroidas-quando-indicado.md
@@ -1,0 +1,125 @@
+---
+title: 'THD para hemorroidas: quando pode ser indicado?'
+metaDescription: 'THD para hemorroidas: saiba quando essa técnica pode ser indicada, quais são as vantagens e limites e o que avaliar com coloproctologista em Curitiba.'
+slug: 'thd-hemorroidas-quando-indicado'
+publishDate: '2026-04-02'
+lastModified: '2026-04-02'
+primaryKeyword: 'THD para hemorroidas'
+secondaryKeywords:
+  - 'THD curitiba'
+  - 'cirurgia hemorroidas curitiba'
+  - 'desarterialização hemorroidária'
+  - 'hemorroidas internas'
+  - 'proctologista curitiba'
+targetAudience: 'patients'
+intent: 'consideration'
+featured: false
+order: 34
+relatedTreatments:
+  - 'hemorroidas'
+relatedPosts:
+  - 'ligadura-elastica-hemorroidas-doi-recuperacao'
+  - 'hemorroida-sempre-cirurgica-tratamento'
+faqs:
+  - question: 'O que significa THD?'
+    answer: 'THD é a sigla para desarterialização hemorroidária transanal, técnica que identifica e reduz o fluxo das artérias hemorroidárias.'
+  - question: 'THD é indicado para qualquer hemorroida?'
+    answer: 'Não. A indicação depende do grau da doença, do tipo de prolapso e das características do paciente.'
+  - question: 'A recuperação costuma ser melhor do que na cirurgia convencional?'
+    answer: 'Em muitos casos, a dor no pós-operatório pode ser menor, mas a recuperação varia conforme a extensão da doença e a técnica escolhida.'
+  - question: 'O resultado é definitivo?'
+    answer: 'Nenhuma técnica elimina totalmente o risco de recorrência. O controle dos hábitos intestinais continua sendo importante.'
+---
+
+_THD é uma das técnicas menos comentadas fora do consultório, mas pode ser uma opção interessante para casos selecionados de hemorroidas internas._
+
+Quando o paciente descobre que existem diferentes tipos de procedimento para hemorroida, é comum aparecer uma nova dúvida:
+"THD pode ser melhor do que operar da forma tradicional?"
+
+A resposta depende menos do nome da técnica e mais do **tipo de hemorroida**, do **grau de prolapso** e do objetivo do tratamento.
+
+## O que é THD?
+
+THD é a sigla para **Transanal Hemorrhoidal Dearterialization**, também chamada de **desarterialização hemorroidária transanal**.
+
+De forma simplificada, a técnica busca:
+
+- identificar as artérias hemorroidárias com auxílio de doppler,
+- reduzir o fluxo sanguíneo para os mamilos hemorroidários,
+- e, em alguns casos, associar correção do prolapso da mucosa.
+
+Ela costuma ser considerada uma abordagem **minimamente invasiva** dentro do arsenal cirúrgico para hemorroidas.
+
+## Em quais situações pode ser indicada?
+
+O THD pode fazer sentido principalmente em:
+
+- hemorroidas internas de **grau II e III**,
+- pacientes com prolapso moderado,
+- casos em que se busca menor trauma tecidual,
+- cenários selecionados em que a anatomia favorece essa estratégia.
+
+Isso não significa que toda hemorroida interna seja tratada dessa maneira.
+Por isso, a avaliação clínica segue sendo essencial.
+
+Para entender o panorama geral das opções, vale revisar a página de [tratamento de hemorroidas](/tratamentos/hemorroidas).
+
+## Quais são as possíveis vantagens?
+
+Entre os motivos que levam essa técnica a ser considerada estão:
+
+- menor trauma em comparação com algumas cirurgias excisionais,
+- possibilidade de pós-operatório mais confortável em casos selecionados,
+- preservação anatômica maior de tecidos externos.
+
+Ainda assim, benefício potencial não é sinônimo de indicação automática.
+
+## Quais são os limites do THD?
+
+Alguns pontos importantes:
+
+- nem toda hemorroida tem perfil anatômico adequado para THD,
+- a presença de componente externo volumoso pode reduzir a utilidade da técnica,
+- existe possibilidade de recorrência,
+- a escolha depende da experiência do especialista e da disponibilidade do método.
+
+Ou seja: THD é uma ferramenta, não uma solução universal.
+
+## THD, ligadura elástica ou cirurgia convencional?
+
+Essa comparação costuma gerar expectativa, mas a melhor pergunta é outra:
+"Qual técnica combina melhor com o meu caso?"
+
+Em alguns pacientes, a **ligadura elástica** pode resolver bem, com tratamento ambulatorial e recuperação rápida.
+Em outros, a doença já pede abordagem cirúrgica mais estruturada.
+Se você ainda está nessa etapa de decisão, o artigo [ligadura elástica para hemorroidas dói?](/blog/ligadura-elastica-hemorroidas-doi-recuperacao) ajuda a comparar contextos.
+
+Já para quem quer entender quando a cirurgia entra na conversa, este conteúdo complementa bem a análise: [hemorroida é sempre cirúrgica?](/blog/hemorroida-sempre-cirurgica-tratamento).
+
+## Como costuma ser a recuperação?
+
+Em muitos casos, a recuperação tende a ser mais confortável do que em técnicas excisionais clássicas.
+Mesmo assim, o pós-operatório pode incluir:
+
+- desconforto ao evacuar,
+- sensação de peso,
+- necessidade de ajuste do ritmo intestinal,
+- acompanhamento para monitorar resposta e cicatrização.
+
+O resultado depende não só da técnica, mas também do controle de fatores como constipação, esforço evacuatório e qualidade das evacuações.
+
+## Conclusão
+
+O THD pode ser uma alternativa útil para **hemorroidas internas selecionadas**, especialmente quando o objetivo é combinar eficácia com menor agressão tecidual.
+Mas a decisão deve ser feita de forma individualizada, comparando essa técnica com outras opções realmente adequadas ao quadro clínico.
+
+No tratamento das hemorroidas, a melhor técnica não é a mais moderna no papel, e sim a que faz mais sentido para o problema que está sendo tratado.
+
+---
+
+**Dra. Ana Luiza Moraes Rocha**  
+Médica Coloproctologista  
+CRM-PR 45351 | RQE 36221  
+Especialista em Coloproctologia
+
+> _Este conteúdo tem caráter educativo e não substitui a consulta médica. Procure sempre orientação profissional para diagnóstico e tratamento adequados._

--- a/content/posts/tratamento-fistulas-anorretais.md
+++ b/content/posts/tratamento-fistulas-anorretais.md
@@ -3,7 +3,7 @@ title: 'Tratamento de fístulas anorretais'
 metaDescription: 'Entenda sintomas, diagnóstico e opções de tratamento para fístula anal com foco em segurança, preservação da continência e menor recorrência.'
 slug: 'tratamento-fistulas-anorretais'
 publishDate: '2026-03-05'
-lastModified: '2026-03-05'
+lastModified: '2026-04-02'
 primaryKeyword: 'fístula anal'
 secondaryKeywords:
   - 'fístulas anorretais'
@@ -11,10 +11,16 @@ secondaryKeywords:
   - 'seton'
   - 'técnica LIFT'
   - 'coloproctologista Curitiba'
+  - 'proctologista curitiba'
 targetAudience: 'patients'
 intent: 'consideration'
 featured: false
 order: 17
+relatedTreatments:
+  - 'cx-fistulas-anorretais'
+relatedPosts:
+  - 'doencas-inflamatorias-intestinais-acompanhamento'
+  - 'proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento'
 faqs:
   - question: 'Fístula anal melhora sozinha?'
     answer: 'Na maioria dos casos, não. Sem tratamento adequado, o trajeto fistuloso tende a persistir e recidivar.'
@@ -34,6 +40,8 @@ Quando mal conduzida, pode gerar recorrência, inflamações repetidas e, princi
 O diferencial no tratamento da fístula está em compreender que **cada trajeto fistuloso é único** e que a decisão terapêutica deve equilibrar eficácia e preservação da função.
 
 A Dra. Ana Luiza, coloproctologista em Curitiba, realiza diagnóstico detalhado e oferece abordagem individualizada para o tratamento de fístulas anorretais, com foco em segurança, preservação esfincteriana e acompanhamento próximo.
+
+Se você quiser comparar as técnicas descritas aqui com a organização da página de atendimento, vale revisar também [cirurgias para fístulas anorretais](/tratamentos/cx-fistulas-anorretais).
 
 ![Ilustração de fístula anorretal e trajeto fistuloso](/images/posts/tratamento-fistulas-anorretais/fistula.webp)
 
@@ -136,6 +144,8 @@ Procure avaliação especializada se você apresenta:
 - Doença de Crohn com sintomas anais.
 
 O tratamento precoce reduz complicações e melhora os resultados funcionais.
+
+Quando existe associação com sintomas intestinais mais amplos ou suspeita de inflamação de base, este conteúdo pode ajudar a complementar o raciocínio: [Doenças inflamatórias intestinais (DII): acompanhamento especializado](/blog/doencas-inflamatorias-intestinais-acompanhamento).
 
 ---
 

--- a/docs/location-seo-spec-report.md
+++ b/docs/location-seo-spec-report.md
@@ -1,0 +1,122 @@
+# Location SEO Spec Report
+
+## Audit findings
+
+- `src/app/layout.tsx` already handled global metadata, canonical, Open Graph, Twitter cards, and local geo hints.
+- JSON-LD already existed in the project via `src/lib/structured-data.ts`, `src/app/page.tsx`, `src/app/sobre/page.tsx`, and treatment pages.
+- The previous structured data strongly favored `Clínica Nassif` and did not model `Specta Endoscopia Digestiva` as a real location entity in the SEO graph.
+- The homepage `LocationsSection` was server-rendered, so its content was crawlable in initial HTML, but the content itself was thin.
+- There was no `/locais-de-atendimento` route, no dedicated location content model, and no reusable location schema helper.
+- Internal linking between locations, treatments, footer, and about content was limited.
+- In code, public location data was only structured for `Clínica Nassif`; `Specta` existed only as a hardcoded homepage card.
+
+## Decision
+
+Chosen approach: `homepage enhancement + dedicated location pages`.
+
+Reasoning:
+
+- There are only two locations, which keeps the architecture simple.
+- Each location supports a distinct user intent:
+  - `Clínica Nassif`: consultation, follow-up, treatment planning.
+  - `Specta Endoscopia Digestiva`: colonoscopy when indicated.
+- This supports useful standalone pages without creating doorway-style duplicates.
+
+## What was implemented
+
+### Shared location model
+
+- Added `src/lib/locations.ts` as the central source for:
+  - location facts
+  - page copy
+  - CTAs
+  - related links
+  - FAQ content
+  - JSON-LD generation
+
+### Structured data
+
+- Updated `src/lib/structured-data.ts` to model the sitewide relationship as:
+  - `MedicalOrganization`
+  - `Physician`
+  - `WebSite`
+- Added homepage location graph via `getHomeLocationsStructuredData()`.
+- Added dedicated location page JSON-LD with:
+  - `WebPage`
+  - `Physician`
+  - `MedicalClinic`
+  - `PostalAddress`
+  - `Service`
+  - `BreadcrumbList`
+
+### New location routes
+
+- Added `/locais-de-atendimento`
+- Added:
+  - `/locais-de-atendimento/clinica-nassif`
+  - `/locais-de-atendimento/specta-endoscopia-digestiva`
+- Added unique metadata, canonical, OG, and Twitter metadata for these pages.
+
+### Internal linking
+
+- Homepage locations section now links to detailed location pages while preserving the original card style.
+- Added location links to:
+  - footer
+  - global navigation
+  - homepage about section
+  - `/sobre`
+  - `/tratamentos`
+
+### Sitemap
+
+- Added the new location routes to `src/app/sitemap.ts`.
+
+## Schema choice reasoning
+
+- I did **not** model the clinics as if the doctor owned them.
+- I preferred `MedicalClinic` for the individual places and kept the doctor's practice relationship centered on `Physician` + `MedicalOrganization`.
+- I used `Service` on location pages instead of more specific medical subtypes when the site copy did not justify a narrower claim.
+- I avoided review schema, unsupported ownership claims, and any facts not visible on the site.
+
+## Files changed
+
+- `src/app/layout.tsx`
+- `src/app/page.tsx`
+- `src/app/sitemap.ts`
+- `src/app/sobre/page.tsx`
+- `src/app/tratamentos/page.tsx`
+- `src/app/locais-de-atendimento/page.tsx`
+- `src/app/locais-de-atendimento/[slug]/page.tsx`
+- `src/components/sections/AboutSection.tsx`
+- `src/components/sections/LocationsSection.tsx`
+- `src/components/ui/Footer.tsx`
+- `src/lib/constants.ts`
+- `src/lib/faq-schema.ts`
+- `src/lib/navigation.ts`
+- `src/lib/locations.ts`
+- `src/lib/structured-data.ts`
+
+## Risks and limitations
+
+- `Specta Endoscopia Digestiva` still has less factual detail available in code than `Clínica Nassif`.
+- The site still has no dedicated contact page; contact intent is handled through WhatsApp and phone CTAs.
+- If the clinic facts used on the site differ from Google Business Profile or clinic-managed listings, the entity association can remain weaker than desired.
+- If future service-location relationships change, `src/lib/locations.ts` must be updated to keep visible content and schema aligned.
+
+## Validation performed
+
+- Ran `npm run build` successfully after implementation.
+- Confirmed the new routes were statically generated:
+  - `/locais-de-atendimento`
+  - `/locais-de-atendimento/clinica-nassif`
+  - `/locais-de-atendimento/specta-endoscopia-digestiva`
+
+## Next manual SEO steps
+
+1. Inspect the homepage in Google Search Console.
+2. Inspect each location page in Google Search Console.
+3. Test the homepage and both location pages in Rich Results Test.
+4. Confirm clinic names and addresses are present in visible HTML exactly as intended.
+5. Request indexing for the updated homepage and each new location page.
+6. Verify consistency between website location details and Google Business Profile / clinic listings.
+7. If the clinics can provide more verified public details, expand the location pages with those facts instead of generic explanatory copy.

--- a/next.config.ts
+++ b/next.config.ts
@@ -23,18 +23,30 @@ const nextConfig: NextConfig = {
   compiler: {
     removeConsole: process.env.NODE_ENV === 'production' ? { exclude: ['error', 'warn'] } : false,
   },
-  // Permanent redirects for renamed/old URLs
+  // Permanent redirects for renamed/old URLs and canonical host enforcement
   redirects: async () => [
-    // Old treatment slug — page lives at /tratamentos/hpv-anal
+    // Specific slug redirects — old URLs that 404'd
     {
       source: '/tratamentos/tratamento-hpv-anal',
       destination: '/tratamentos/hpv-anal',
       permanent: true,
     },
-    // Old short blog slug — file is cisto-pilonidal-cirurgia-laser-quando-operar
     {
       source: '/blog/cisto-pilonidal-cirurgia-laser',
       destination: '/blog/cisto-pilonidal-cirurgia-laser-quando-operar',
+      permanent: true,
+    },
+    // Canonical host enforcement — belt-and-suspenders alongside Vercel platform config
+    {
+      source: '/:path*',
+      has: [{ type: 'host', value: 'analuizarocha.com.br' }],
+      destination: 'https://www.analuizarocha.com.br/:path*',
+      permanent: true,
+    },
+    {
+      source: '/:path*',
+      has: [{ type: 'header', key: 'x-forwarded-proto', value: 'http' }],
+      destination: 'https://www.analuizarocha.com.br/:path*',
       permanent: true,
     },
   ],

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -6,6 +6,7 @@ import remarkGfm from 'remark-gfm'
 import { CallToActionCard } from '@/components/ui/CallToActionCard'
 import {
   getPostBySlug,
+  getAllPosts,
   getAllPostSlugs,
   generateBlogPostSchema,
   getTargetAudienceLabel,
@@ -21,6 +22,12 @@ import {
 } from '@/lib/constants'
 import { LinkButton } from '@/components/ui/LinkButton'
 import { MdxImage } from '@/components/ui/MdxImage'
+import { RelatedTreatmentsSection } from '@/components/ui/RelatedTreatmentsSection'
+import { RelatedPostsSection } from '@/components/ui/RelatedPostsSection'
+import {
+  getResolvedRelatedPostSlugs,
+  getResolvedRelatedTreatmentSlugs,
+} from '@/lib/content-relationships'
 
 interface BlogPostPageProps {
   params: Promise<{
@@ -104,12 +111,18 @@ export async function generateMetadata({ params }: BlogPostPageProps): Promise<M
 export default async function BlogPostPage({ params }: BlogPostPageProps) {
   const { slug } = await params
   const post = getPostBySlug(slug)
+  const allPosts = getAllPosts()
 
   if (!post) {
     notFound()
   }
 
   const schema = generateBlogPostSchema(post)
+  const relatedTreatmentSlugs = getResolvedRelatedTreatmentSlugs(post)
+  const relatedPostSlugs = getResolvedRelatedPostSlugs(post, allPosts)
+  const relatedPosts = relatedPostSlugs
+    .map((relatedSlug) => allPosts.find((candidate) => candidate.slug === relatedSlug))
+    .filter((candidate): candidate is NonNullable<typeof candidate> => Boolean(candidate))
 
   return (
     <>
@@ -206,6 +219,9 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
                 components={{ img: MdxImage }}
               />
             </div>
+
+            <RelatedTreatmentsSection treatmentSlugs={relatedTreatmentSlugs} />
+            <RelatedPostsSection posts={relatedPosts} />
           </div>
 
           {/* Article Footer */}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -18,9 +18,11 @@ const BLOG_PAGE_TITLE = 'Blog — Saúde intestinal sem tabu'
 export const metadata: Metadata = {
   title: BLOG_PAGE_TITLE,
   description:
-    'Orientações práticas sobre hemorroidas, fissuras, intestino preso, HPV anal e mais. Conteúdo direto, sem jargão, escrito por quem trata.',
+    'Orientações práticas de coloproctologia e proctologia sobre hemorroidas, fissuras, intestino preso, HPV anal e mais.',
   keywords: [
     'blog coloproctologia',
+    'blog proctologia',
+    'proctologista curitiba',
     'artigos coloproctologista curitiba',
     'saúde intestinal',
     'tratamento hemorroidas',
@@ -32,7 +34,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: BLOG_PAGE_TITLE,
     description:
-      'Orientações práticas sobre hemorroidas, fissuras, intestino preso, HPV anal e mais. Conteúdo direto, sem jargão, escrito por quem trata.',
+      'Orientações práticas de coloproctologia e proctologia sobre hemorroidas, fissuras, intestino preso, HPV anal e mais.',
     type: 'website',
     locale: 'pt_BR',
     url: `${WEBSITE_URL}/blog`,
@@ -50,7 +52,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: BLOG_PAGE_TITLE,
     description:
-      'Orientações práticas sobre hemorroidas, fissuras, intestino preso, HPV anal e mais. Conteúdo direto, sem jargão, escrito por quem trata.',
+      'Orientações práticas de coloproctologia e proctologia sobre hemorroidas, fissuras, intestino preso, HPV anal e mais.',
     creator: TAG_INSTAGRAM,
     site: TAG_INSTAGRAM,
     images: [`${WEBSITE_URL}/og-image.jpg`],
@@ -81,12 +83,12 @@ export default function BlogPage() {
         <div className="max-w-[1760px] mx-auto px-6 sm:px-8 lg:px-10 xl:px-12">
           <div className="mx-auto max-w-4xl text-center mb-16 lg:mb-20">
             <h1 className="text-3xl sm:text-5xl lg:text-6xl font-serif font-bold text-primary mb-8">
-              Cuidando da sua saúde intestinal
+              Cuidando da sua saúde intestinal com informação clara
             </h1>
             <div className="text-lg md:text-xl lg:text-2xl leading-relaxed text-secondary font-medium">
               <p>
                 Aqui compartilho conhecimentos, dicas práticas e orientações sobre coloproctologia
-                para ajudar você a entender melhor sua saúde intestinal
+                e proctologia para ajudar você a entender melhor sua saúde intestinal
               </p>
             </div>
           </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -46,7 +46,7 @@ export const metadata: Metadata = {
     template: `%s | ${SITE_BRAND}`,
   },
   description:
-    'Médica coloproctologista e proctologista em Curitiba, no Batel. Cuidado clínico e cirúrgico com foco em hemorroidas, fissuras, fístulas, HPV anal e doenças inflamatórias intestinais.',
+    'Médica coloproctologista e proctologista em Curitiba. Consultas em coloproctologia no Batel e organização de exames quando indicados, com foco em hemorroidas, fissuras, fístulas, HPV anal e doenças inflamatórias intestinais.',
   keywords: [
     'coloproctologista curitiba',
     'coloproctologia curitiba',
@@ -67,8 +67,11 @@ export const metadata: Metadata = {
     'cisto pilonidal cirurgia',
     'fístula anorretal',
     'câncer canal anal',
+    'onde atende dra ana luiza rocha',
     'batel curitiba',
+    'mercês curitiba',
     'clínica nassif',
+    'specta endoscopia digestiva',
     'crm pr 45351',
   ],
   authors: [{ name: DR_NAME }],
@@ -103,7 +106,7 @@ export const metadata: Metadata = {
     url: WEBSITE_URL,
     title: DEFAULT_SITE_TITLE,
     description:
-      'Dra. Ana Luiza M. Rocha, médica coloproctologista e proctologista em Curitiba. Cuidado clínico e cirúrgico humanizado para hemorroidas, fissuras anais, HPV e doenças inflamatórias intestinais.',
+      'Dra. Ana Luiza M. Rocha, médica coloproctologista e proctologista em Curitiba. Consultas em coloproctologia e cuidado humanizado com orientação clara sobre locais de atendimento e exames quando indicados.',
     siteName: `${DR_NAME} - Coloproctologia`,
     images: [
       {
@@ -126,7 +129,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: DEFAULT_SITE_TITLE,
     description:
-      'Médica coloproctologista e proctologista oferecendo cuidado clínico e cirúrgico humanizado em Curitiba.',
+      'Médica coloproctologista e proctologista oferecendo cuidado clínico e cirúrgico humanizado em Curitiba, com informações claras sobre locais de atendimento.',
     images: [
       {
         url: `${WEBSITE_URL}/images/og.png`,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,7 +37,7 @@ const literata = Literata({
 })
 
 const SITE_BRAND = DR_NAME_ABBREVIATED
-const DEFAULT_SITE_TITLE = `${SITE_BRAND} | Coloproctologista Curitiba`
+const DEFAULT_SITE_TITLE = `${SITE_BRAND} | Coloproctologista e Proctologista Curitiba`
 
 export const metadata: Metadata = {
   metadataBase: new URL(WEBSITE_URL),
@@ -46,14 +46,16 @@ export const metadata: Metadata = {
     template: `%s | ${SITE_BRAND}`,
   },
   description:
-    'Coloproctologista em Curitiba. Cuidado clínico e cirúrgico com foco em hemorroidas, fissuras, fístulas, HPV anal e doenças inflamatórias intestinais. Clínica Nassif, Batel.',
+    'Médica coloproctologista e proctologista em Curitiba, no Batel. Cuidado clínico e cirúrgico com foco em hemorroidas, fissuras, fístulas, HPV anal e doenças inflamatórias intestinais.',
   keywords: [
     'coloproctologista curitiba',
     'coloproctologia curitiba',
+    'proctologista curitiba',
+    'proctologia curitiba',
     'ana luiza rocha',
     'cirurgia hemorroidas curitiba',
     'tratamento fissura anal',
-    'proctologista curitiba',
+    'médico proctologista curitiba',
     'médica intestino curitiba',
     'cirurgia ânus curitiba',
     'HPV anal tratamento',
@@ -101,7 +103,7 @@ export const metadata: Metadata = {
     url: WEBSITE_URL,
     title: DEFAULT_SITE_TITLE,
     description:
-      'Dra. Ana Luiza M. Rocha, especialista em Coloproctologia em Curitiba. Cuidado clínico e cirúrgico humanizado para tratamento de hemorroidas, fissuras anais, HPV e doenças inflamatórias intestinais.',
+      'Dra. Ana Luiza M. Rocha, médica coloproctologista e proctologista em Curitiba. Cuidado clínico e cirúrgico humanizado para hemorroidas, fissuras anais, HPV e doenças inflamatórias intestinais.',
     siteName: `${DR_NAME} - Coloproctologia`,
     images: [
       {
@@ -124,7 +126,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: DEFAULT_SITE_TITLE,
     description:
-      'Especialista em Coloproctologia oferecendo cuidado clínico e cirúrgico humanizado do intestino, reto e ânus em Curitiba.',
+      'Médica coloproctologista e proctologista oferecendo cuidado clínico e cirúrgico humanizado em Curitiba.',
     images: [
       {
         url: `${WEBSITE_URL}/images/og.png`,

--- a/src/app/locais-de-atendimento/[slug]/page.tsx
+++ b/src/app/locais-de-atendimento/[slug]/page.tsx
@@ -1,0 +1,248 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { ArrowRight, Phone } from 'lucide-react'
+import { Breadcrumb } from '@/components/ui/Breadcrumb'
+import { LinkButton } from '@/components/ui/LinkButton'
+import { Badge } from '@/components/ui/Badge'
+import { CallToActionCard } from '@/components/ui/CallToActionCard'
+import { generateOpenGraphMetadata, generateTwitterMetadata } from '@/lib/seo-schemas'
+import {
+  getLocationBySlug,
+  getLocationPageStructuredData,
+  getLocationPath,
+  locationPages,
+} from '@/lib/locations'
+import { WEBSITE_URL } from '@/lib/constants'
+
+interface LocationPageProps {
+  params: Promise<{
+    slug: string
+  }>
+}
+
+export async function generateStaticParams() {
+  return locationPages.map((location) => ({
+    slug: location.slug,
+  }))
+}
+
+export async function generateMetadata({ params }: LocationPageProps): Promise<Metadata> {
+  const { slug } = await params
+  const location = getLocationBySlug(slug)
+
+  if (!location) {
+    return {
+      title: 'Local não encontrado',
+    }
+  }
+
+  const pageUrl = `${WEBSITE_URL}${getLocationPath(location.slug)}`
+
+  return {
+    title: location.metaTitle,
+    description: location.metaDescription,
+    alternates: {
+      canonical: pageUrl,
+    },
+    openGraph: generateOpenGraphMetadata({
+      title: location.metaTitle,
+      description: location.metaDescription,
+      url: pageUrl,
+    }),
+    twitter: generateTwitterMetadata({
+      title: location.metaTitle,
+      description: location.metaDescription,
+      url: pageUrl,
+    }),
+  }
+}
+
+export default async function LocationPage({ params }: LocationPageProps) {
+  const { slug } = await params
+  const location = getLocationBySlug(slug)
+
+  if (!location) {
+    notFound()
+  }
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: getLocationPageStructuredData(location),
+        }}
+      />
+
+      <section className="section bg-background pt-24 md:pt-28 animate-fade-in">
+        <div className="max-w-[1760px] mx-auto px-6 sm:px-8 lg:px-10 xl:px-12">
+          <Breadcrumb
+            items={[
+              { label: 'Início', href: '/' },
+              { label: 'Locais de atendimento', href: '/locais-de-atendimento' },
+              { label: location.name },
+            ]}
+          />
+
+          <div className="mx-auto max-w-4xl">
+            <header className="mb-10 lg:mb-12 text-center">
+              <div className="flex flex-wrap items-center justify-center gap-2 mb-5">
+                <Badge variant="secondary" size="lg">
+                  {location.badgeLabel}
+                </Badge>
+              </div>
+
+              <h1 className="text-3xl sm:text-4xl lg:text-5xl font-serif font-bold text-primary mb-6 leading-tight">
+                {location.pageTitle}
+              </h1>
+
+              <p className="text-lg md:text-xl lg:text-2xl text-secondary leading-relaxed font-medium max-w-3xl mx-auto">
+                {location.visibleRelationshipText}
+              </p>
+            </header>
+
+            <div className="rounded-3xl border border-secondary/20 bg-secondary/10 p-8 lg:p-10 mb-10">
+              <h2 className="text-2xl lg:text-3xl font-serif font-bold text-primary mb-4">
+                Endereço e contato
+              </h2>
+
+              <address className="not-italic text-lg text-secondary leading-relaxed mb-5">
+                {location.addressLines[0]}
+                <br />
+                {location.addressLines[1]}
+              </address>
+
+              <div className="flex flex-col sm:flex-row sm:items-center gap-4 text-base lg:text-lg">
+                <a
+                  href={location.phoneHref}
+                  className="inline-flex items-center gap-3 text-secondary hover:text-primary transition-colors"
+                >
+                  <Phone className="size-5 text-primary" aria-hidden="true" />
+                  <span>{location.phoneDisplay}</span>
+                </a>
+
+                <a
+                  href={location.mapUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 text-primary hover:text-primary/80 transition-colors font-medium"
+                >
+                  Ver mapa e rota
+                  <ArrowRight className="size-4" aria-hidden="true" />
+                </a>
+              </div>
+            </div>
+
+            <main className="prose prose-lg max-w-none mb-10 lg:mb-12">
+              <h2 className="text-3xl font-serif font-bold text-primary mb-6 text-center">
+                Como este local se encaixa no cuidado
+              </h2>
+
+              {location.overviewParagraphs.map((paragraph) => (
+                <p key={paragraph} className="text-lg text-secondary leading-relaxed mb-4">
+                  {paragraph}
+                </p>
+              ))}
+
+              <h2 className="text-3xl font-serif font-bold text-primary mb-6 text-center">
+                {location.servicesTitle}
+              </h2>
+              <ul>
+                {location.services.map((service) => (
+                  <li key={service}>{service}</li>
+                ))}
+              </ul>
+
+              <h2 className="text-3xl font-serif font-bold text-primary mb-6 text-center">
+                Informações práticas
+              </h2>
+              <ul>
+                {location.practicalInfo.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </main>
+
+            <CallToActionCard
+              title="Agendamento"
+              body={<p>{location.schedulingDescription}</p>}
+              actions={
+                <>
+                  <LinkButton href={location.whatsappHref} external newTab variant="primary">
+                    {location.primaryCtaLabel}
+                  </LinkButton>
+                  <LinkButton href="/locais-de-atendimento" variant="outline">
+                    Ver todos os locais
+                  </LinkButton>
+                </>
+              }
+              variant="secondary"
+            />
+
+            <div className="rounded-3xl border border-secondary/20 bg-secondary/10 p-8 lg:p-10 mb-10">
+              <h2 className="text-2xl lg:text-3xl font-serif font-bold text-primary mb-5">
+                Tratamentos relacionados
+              </h2>
+              <div className="space-y-3">
+                {location.relatedTreatments.map((link) => (
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    className="flex items-start justify-between gap-3 rounded-2xl border border-secondary/15 bg-background px-4 py-4 text-secondary hover:border-primary/30 hover:text-primary transition-colors"
+                  >
+                    <span>{link.label}</span>
+                    <ArrowRight className="size-4 flex-shrink-0 mt-1" aria-hidden="true" />
+                  </Link>
+                ))}
+              </div>
+            </div>
+
+            {location.relatedArticles && location.relatedArticles.length > 0 && (
+              <div className="rounded-3xl border border-secondary/20 bg-secondary/10 p-8 lg:p-10 mb-10">
+                <h2 className="text-2xl lg:text-3xl font-serif font-bold text-primary mb-5">
+                  Leituras úteis
+                </h2>
+                <div className="space-y-3">
+                  {location.relatedArticles.map((link) => (
+                    <Link
+                      key={link.href}
+                      href={link.href}
+                      className="flex items-start justify-between gap-3 rounded-2xl border border-secondary/15 bg-background px-4 py-4 text-secondary hover:border-primary/30 hover:text-primary transition-colors"
+                    >
+                      <span>{link.label}</span>
+                      <ArrowRight className="size-4 flex-shrink-0 mt-1" aria-hidden="true" />
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div className="rounded-3xl border border-secondary/20 bg-background p-8 lg:p-10 mb-8">
+              <h2 className="text-2xl lg:text-3xl font-serif font-bold text-primary mb-6">
+                Perguntas frequentes
+              </h2>
+              <div className="space-y-6">
+                {location.faq.map((item) => (
+                  <div key={item.question}>
+                    <h3 className="text-xl font-semibold text-primary mb-2">{item.question}</h3>
+                    <p className="text-lg text-secondary leading-relaxed">{item.answer}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="text-center">
+              <Link
+                href="/"
+                className="inline-flex items-center text-primary hover:text-primary/80 font-medium transition-colors text-lg"
+              >
+                ← Voltar ao início
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+    </>
+  )
+}

--- a/src/app/locais-de-atendimento/page.tsx
+++ b/src/app/locais-de-atendimento/page.tsx
@@ -1,0 +1,191 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowRight, MapPin } from 'lucide-react'
+import { Breadcrumb } from '@/components/ui/Breadcrumb'
+import { LinkButton } from '@/components/ui/LinkButton'
+import { Badge } from '@/components/ui/Badge'
+import { CallToActionCard } from '@/components/ui/CallToActionCard'
+import { generateOpenGraphMetadata, generateTwitterMetadata } from '@/lib/seo-schemas'
+import {
+  LOCATIONS_BASE_PATH,
+  getLocationPath,
+  getLocationsIndexStructuredData,
+  locationPages,
+} from '@/lib/locations'
+import { WEBSITE_URL } from '@/lib/constants'
+
+const pageTitle = 'Locais de atendimento em Curitiba'
+const pageDescription =
+  'Veja onde a Dra. Ana Luiza Rocha atende em Curitiba, com informações sobre consulta em coloproctologia, colonoscopia, endereços e agendamento.'
+const pageUrl = `${WEBSITE_URL}${LOCATIONS_BASE_PATH}`
+
+export const metadata: Metadata = {
+  title: pageTitle,
+  description: pageDescription,
+  alternates: {
+    canonical: pageUrl,
+  },
+  openGraph: generateOpenGraphMetadata({
+    title: pageTitle,
+    description: pageDescription,
+    url: pageUrl,
+  }),
+  twitter: generateTwitterMetadata({
+    title: pageTitle,
+    description: pageDescription,
+    url: pageUrl,
+  }),
+}
+
+export default function LocationsIndexPage() {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: getLocationsIndexStructuredData(),
+        }}
+      />
+
+      <section className="section bg-background pt-24 md:pt-28 animate-fade-in">
+        <div className="max-w-[1760px] mx-auto px-6 sm:px-8 lg:px-10 xl:px-12">
+          <Breadcrumb items={[{ label: 'Início', href: '/' }, { label: 'Locais de atendimento' }]} />
+
+          <div className="mx-auto max-w-4xl text-center mb-12 lg:mb-16">
+            <div className="flex flex-wrap items-center justify-center gap-2 mb-5">
+              <Badge variant="secondary" size="lg">
+                Consulta em coloproctologia
+              </Badge>
+              <Badge variant="secondary" size="lg">
+                Colonoscopia quando indicada
+              </Badge>
+            </div>
+
+            <h1 className="text-3xl sm:text-5xl lg:text-6xl font-serif font-bold text-primary mb-6">
+              Locais de atendimento da Dra. Ana Luiza Rocha
+            </h1>
+
+            <div className="text-lg md:text-xl lg:text-2xl leading-relaxed text-secondary font-medium space-y-4">
+              <p>
+                Aqui você encontra os locais relacionados ao atendimento da Dra. Ana Luiza em
+                Curitiba.
+              </p>
+              <p>
+                Um deles concentra as consultas e o acompanhamento em coloproctologia. O outro é
+                usado quando a colonoscopia faz parte da investigação ou do rastreio indicado.
+              </p>
+            </div>
+          </div>
+
+          <div className="mx-auto max-w-5xl grid grid-cols-1 gap-6 lg:gap-8 mb-12 lg:mb-16">
+            {locationPages.map((location) => (
+              <article
+                key={location.slug}
+                className="rounded-3xl border border-secondary/20 bg-secondary/10 p-7 lg:p-8 shadow-sm"
+              >
+                <div className="flex items-start gap-4 mb-5">
+                  <div className="rounded-full bg-primary/10 p-3 flex-shrink-0">
+                    <MapPin className="size-5 text-primary" aria-hidden="true" />
+                  </div>
+
+                  <div className="min-w-0 flex-1">
+                    <Badge variant="secondary" className="mb-3">
+                      {location.badgeLabel}
+                    </Badge>
+                    <h2 className="text-2xl lg:text-3xl font-serif font-bold text-primary mb-3">
+                      {location.name}
+                    </h2>
+                    <p className="text-lg text-secondary leading-relaxed mb-4">
+                      {location.visibleRelationshipText}
+                    </p>
+                    <address className="not-italic text-base lg:text-lg text-secondary leading-relaxed">
+                      {location.addressLines[0]}
+                      <br />
+                      {location.addressLines[1]}
+                    </address>
+                  </div>
+                </div>
+
+                <p className="text-base lg:text-lg text-secondary leading-relaxed mb-5">
+                  {location.cardDescription}
+                </p>
+
+                <ul className="space-y-3 text-base lg:text-lg text-secondary mb-6">
+                  {location.services.slice(0, 2).map((service) => (
+                    <li key={service} className="flex gap-3">
+                      <span className="mt-2 size-2 rounded-full bg-primary/50 flex-shrink-0" />
+                      <span>{service}</span>
+                    </li>
+                  ))}
+                </ul>
+
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 pt-5 border-t border-secondary/10">
+                  <div className="flex flex-wrap gap-4 text-sm lg:text-base font-medium">
+                    <a
+                      href={location.mapUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-primary hover:text-primary/80 transition-colors"
+                    >
+                      Ver mapa
+                    </a>
+                    <Link
+                      href={getLocationPath(location.slug)}
+                      className="inline-flex items-center gap-2 text-primary hover:text-primary/80 transition-colors"
+                    >
+                      Ver detalhes
+                      <ArrowRight className="size-4" aria-hidden="true" />
+                    </Link>
+                  </div>
+
+                  <LinkButton
+                    href={location.whatsappHref}
+                    external
+                    newTab
+                    variant="primary"
+                    className="w-full sm:w-auto text-sm font-semibold px-5"
+                  >
+                    {location.primaryCtaLabel}
+                  </LinkButton>
+                </div>
+              </article>
+            ))}
+          </div>
+
+          <div className="mx-auto max-w-5xl">
+            <CallToActionCard
+              title="Ainda em dúvida sobre qual local faz mais sentido?"
+              body={
+                <p>
+                  Se a sua necessidade é consulta, retorno ou definição de conduta, comece pela
+                  avaliação em coloproctologia. Se houver indicação de colonoscopia, a orientação
+                  pode seguir para o local apropriado.
+                </p>
+              }
+              actions={
+                <>
+                  <LinkButton href="/tratamentos" variant="outline">
+                    Ver tratamentos
+                  </LinkButton>
+                  <LinkButton href="/sobre" variant="subtle">
+                    Conhecer a trajetória da Dra. Ana
+                  </LinkButton>
+                </>
+              }
+              variant="secondary"
+            />
+          </div>
+
+          <div className="mt-2 text-center">
+            <Link
+              href="/"
+              className="inline-flex items-center text-primary hover:text-primary/80 font-medium transition-colors text-lg"
+            >
+              ← Voltar ao início
+            </Link>
+          </div>
+        </div>
+      </section>
+    </>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,10 +8,17 @@ import {
   AboutSection,
 } from '@/components/sections'
 import { getFAQSchema } from '@/lib/faq-schema'
+import { getHomeLocationsStructuredData } from '@/lib/locations'
 
 export default function Home() {
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: getHomeLocationsStructuredData(),
+        }}
+      />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -5,6 +5,9 @@ import { WEBSITE_URL } from '@/lib/constants'
 const STATIC_ROUTE_LAST_MODIFIED: Record<string, string> = {
   '/': '2026-04-01',
   '/blog': '2026-04-01',
+  '/locais-de-atendimento': '2026-04-11',
+  '/locais-de-atendimento/clinica-nassif': '2026-04-11',
+  '/locais-de-atendimento/specta-endoscopia-digestiva': '2026-04-11',
   '/sobre': '2026-03-20',
   '/tratamentos': '2026-03-20',
   '/tratamentos/hemorroidas': '2026-03-20',
@@ -67,6 +70,24 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: STATIC_ROUTE_LAST_MODIFIED['/tratamentos'],
       changeFrequency: 'monthly' as const,
       priority: 0.95,
+    },
+    {
+      url: `${WEBSITE_URL}/locais-de-atendimento`,
+      lastModified: STATIC_ROUTE_LAST_MODIFIED['/locais-de-atendimento'],
+      changeFrequency: 'monthly' as const,
+      priority: 0.9,
+    },
+    {
+      url: `${WEBSITE_URL}/locais-de-atendimento/clinica-nassif`,
+      lastModified: STATIC_ROUTE_LAST_MODIFIED['/locais-de-atendimento/clinica-nassif'],
+      changeFrequency: 'monthly' as const,
+      priority: 0.8,
+    },
+    {
+      url: `${WEBSITE_URL}/locais-de-atendimento/specta-endoscopia-digestiva`,
+      lastModified: STATIC_ROUTE_LAST_MODIFIED['/locais-de-atendimento/specta-endoscopia-digestiva'],
+      changeFrequency: 'monthly' as const,
+      priority: 0.8,
     },
     // Individual treatment pages - Very high priority
     ...treatmentEntries,

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -9,9 +9,6 @@ import {
   WPP_NUMBER_NASSIF,
   WHATSAPP_MSG_TEXT_ENCODED,
   WEBSITE_URL,
-  CLINICA_NASSIF,
-  DR_NAME,
-  WPP_NUMBER_NASSIF_FORMATTED,
   URL_INSTAGRAM,
   CRM_NUMBER,
   RQE_NUMBER,
@@ -23,7 +20,6 @@ import {
   generateBreadcrumbSchema,
   generateOpenGraphMetadata,
   generateTwitterMetadata,
-  generateLocalBusinessSchema,
   type BreadcrumbItem,
 } from '@/lib/seo-schemas'
 import {
@@ -200,36 +196,6 @@ export default function SobrePage() {
               addressCountry: 'BR',
             },
           }),
-        }}
-      />
-
-      {/* LocalBusiness Schema */}
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify(
-            generateLocalBusinessSchema({
-              name: `${DR_NAME} - Coloproctologia`,
-              description:
-                'Consultas de Coloproctologia com atendimento humanizado e especializado em Curitiba. Diagnóstico e tratamento de doenças do intestino, reto e ânus.',
-              address: {
-                streetAddress: CLINICA_NASSIF.address,
-                addressLocality: CLINICA_NASSIF.city,
-                addressRegion: CLINICA_NASSIF.state,
-                postalCode: CLINICA_NASSIF.cep,
-                addressCountry: 'BR',
-              },
-              geo: {
-                latitude: CLINICA_NASSIF.coordinates.latitude,
-                longitude: CLINICA_NASSIF.coordinates.longitude,
-              },
-              telephone: WPP_NUMBER_NASSIF_FORMATTED,
-              url: WEBSITE_URL,
-              image: `${WEBSITE_URL}/images/og.png`,
-              priceRange: '$$',
-              openingHours: CLINICA_NASSIF.openingHours,
-            })
-          ),
         }}
       />
 
@@ -593,6 +559,14 @@ export default function SobrePage() {
                   className="text-lg px-8 py-4 font-semibold text-nowrap shadow-lg hover:shadow-xl transform  transition-all duration-300"
                 >
                   Conhecer tratamentos
+                </LinkButton>
+                <LinkButton
+                  href="/locais-de-atendimento"
+                  size="xl"
+                  variant="subtle"
+                  className="text-lg px-8 py-4 font-semibold text-nowrap shadow-lg hover:shadow-xl transform transition-all duration-300"
+                >
+                  Ver locais de atendimento
                 </LinkButton>
               </>
             }

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -40,7 +40,7 @@ import {
 
 const pageTitle = 'Formação e trajetória profissional'
 const pageDescription =
-  'Residência em cirurgia geral, especialização em coloproctologia e fellowship internacional em cirurgia colorretal. Conheça quem cuida de você.'
+  'Residência em cirurgia geral, especialização em coloproctologia, atuação em proctologia e fellowship internacional em cirurgia colorretal. Conheça quem cuida de você.'
 const pageUrl = `${WEBSITE_URL}/sobre`
 
 export const metadata: Metadata = {
@@ -51,7 +51,9 @@ export const metadata: Metadata = {
     'dra ana luiza moraes rocha',
     'crm pr 45351',
     'proctologista curitiba',
+    'proctologia curitiba',
     'medica coloproctologista',
+    'medica proctologista curitiba',
     'cirurgia colorretal curitiba',
   ],
   alternates: {
@@ -258,8 +260,8 @@ export default function SobrePage() {
             </h1>
 
             <h2 className="text-start sm:text-center text-lg md:text-xl lg:text-2xl text-secondary mb-8 leading-relaxed font-medium w-full flex flex-col items-center justify-center max-w-3xl mx-auto">
-              Especialista em Coloproctologia com formação internacional, dedicada ao cuidado
-              integral e humanizado de cada paciente.
+              Médica coloproctologista e proctologista em Curitiba, com formação internacional e
+              dedicada ao cuidado integral e humanizado de cada paciente.
             </h2>
           </div>
 
@@ -272,9 +274,9 @@ export default function SobrePage() {
               forma integral. Durante a graduação em Medicina na <strong>{PUC_PR}</strong>,
               desenvolvi a base sólida da minha formação. Foi durante a&nbsp;
               <strong>residência em Cirurgia Geral, no {HOSPITAL_SANTA_CASA}</strong>, que descobri
-              meu amor pela <strong>coloproctologia</strong> — especialidade que une conhecimento
-              técnico avançado com o cuidado humanizado que sempre busquei oferecer aos meus
-              pacientes.
+              meu amor pela <strong>coloproctologia</strong> e pela atuação em
+              <strong> proctologia</strong> — especialidade que une conhecimento técnico avançado
+              com o cuidado humanizado que sempre busquei oferecer aos meus pacientes.
             </p>
 
             {/* Professional Images Grid */}

--- a/src/app/tratamentos/page.tsx
+++ b/src/app/tratamentos/page.tsx
@@ -173,6 +173,10 @@ export default function ServicosPage() {
                 <br />
                 Atendimento humanizado com a mais alta qualidade técnica.
               </p>
+              <p className="text-base lg:text-lg text-secondary/80 leading-relaxed mb-6">
+                Se quiser entender em qual clínica a consulta ou o exame faz mais sentido, veja
+                também os locais de atendimento.
+              </p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center">
                 <LinkButton
                   href={`https://wa.me/${WPP_NUMBER_NASSIF}/?text=${WHATSAPP_MSG_TEXT_ENCODED}`}
@@ -192,6 +196,14 @@ export default function ServicosPage() {
                   className="text-lg px-8 py-4 font-semibold text-nowrap shadow-lg hover:shadow-xl transform  transition-all duration-300"
                 >
                   Ver artigos
+                </LinkButton>
+                <LinkButton
+                  href="/locais-de-atendimento"
+                  size="xl"
+                  variant="subtle"
+                  className="text-lg px-8 py-4 font-semibold text-nowrap shadow-lg hover:shadow-xl transform transition-all duration-300"
+                >
+                  Ver locais
                 </LinkButton>
               </div>
             </div>

--- a/src/app/tratamentos/page.tsx
+++ b/src/app/tratamentos/page.tsx
@@ -8,12 +8,13 @@ import { getTreatmentImageBySlug } from '@/lib/treatment-images'
 export const metadata: Metadata = {
   title: 'Tratamentos em Coloproctologia',
   description:
-    'Do diagnóstico ao pós-operatório: cirurgia a laser, hemorroidas, fístulas, cisto pilonidal, HPV anal e doenças inflamatórias intestinais. Conheça cada abordagem.',
+    'Tratamentos em coloproctologia e proctologia em Curitiba: cirurgia a laser, hemorroidas, fístulas, cisto pilonidal, HPV anal e doenças inflamatórias intestinais.',
   keywords: [
     'coloproctologia curitiba',
+    'proctologia curitiba',
+    'proctologista curitiba',
     'cirurgia hemorroidas curitiba',
     'tratamento fissura anal',
-    'proctologista curitiba',
     'cirurgia laser curitiba',
     'HPV anal curitiba',
     'cisto pilonidal curitiba',
@@ -126,12 +127,12 @@ export default function ServicosPage() {
             </h1>
             <div className="text-lg md:text-xl lg:text-2xl leading-relaxed text-secondary font-medium space-y-4">
               <p>
-                Oferecemos tratamentos especializados com tecnologia avançada e cuidado humanizado
-                para todas as condições coloproctológicas.
+                Oferecemos tratamentos especializados em coloproctologia e proctologia, com
+                tecnologia avançada e cuidado humanizado em Curitiba.
               </p>
               <p>
                 Nossa abordagem é sempre individualizada, buscando o melhor resultado com o menor
-                desconforto possível.
+                desconforto possível no contexto clínico e cirúrgico de cada paciente.
               </p>
             </div>
           </div>

--- a/src/app/tratamentos/page.tsx
+++ b/src/app/tratamentos/page.tsx
@@ -191,7 +191,7 @@ export default function ServicosPage() {
                   variant="outline"
                   className="text-lg px-8 py-4 font-semibold text-nowrap shadow-lg hover:shadow-xl transform  transition-all duration-300"
                 >
-                  Artigos educativos
+                  Ver artigos
                 </LinkButton>
               </div>
             </div>

--- a/src/components/sections/AboutSection.tsx
+++ b/src/components/sections/AboutSection.tsx
@@ -74,9 +74,12 @@ export function AboutSection() {
           </div>
         </div>
 
-        <div className="text-center mb-8 lg:mb-4 mt-4 lg:mt-8">
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-8 lg:mb-4 mt-4 lg:mt-8">
           <LinkButton href="/sobre" variant="outline" size="lg">
             Conheça minha trajetória
+          </LinkButton>
+          <LinkButton href="/locais-de-atendimento" variant="subtle" size="lg">
+            Ver locais de atendimento
           </LinkButton>
         </div>
       </div>

--- a/src/components/sections/AboutSection.tsx
+++ b/src/components/sections/AboutSection.tsx
@@ -48,8 +48,8 @@ export function AboutSection() {
             Quem é Dra. Ana Luiza?
           </h2>
           <div className="text-lg md:text-xl lg:text-2xl leading-relaxed text-secondary font-medium space-y-4">
-            <p>Especialista em coloproctologia com formação internacional.</p>
-            <p>Dedicada ao cuidado integral e humanizado de cada paciente.</p>
+            <p>Médica coloproctologista e proctologista em Curitiba, com formação internacional.</p>
+            <p>Dedicada ao cuidado integral e humanizado de cada paciente no Batel.</p>
           </div>
         </div>
 

--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -34,12 +34,9 @@ export function HeroSection() {
             </h1>
 
             {/* Enhanced Subtitle - Bigger and Better */}
-            <div className="mt-8 mb-12 space-y-4">
+            <div className="mt-8 mb-12">
               <p className="text-2xl lg:text-3xl xl:text-4xl font-serif font-medium text-secondary leading-relaxed lg:max-w-xl">
                 Cuidado Clínico e Cirúrgico do Intestino, Reto e Ânus
-              </p>
-              <p className="text-base sm:text-lg lg:text-xl text-secondary/90 leading-relaxed lg:max-w-xl">
-                Atendimento humanizado em coloproctologia e proctologia em Curitiba.
               </p>
             </div>
 

--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -38,6 +38,9 @@ export function HeroSection() {
               <p className="text-2xl lg:text-3xl xl:text-4xl font-serif font-medium text-secondary leading-relaxed lg:max-w-xl">
                 Cuidado Clínico e Cirúrgico do Intestino, Reto e Ânus
               </p>
+              <p className="text-base sm:text-lg lg:text-xl text-secondary/90 leading-relaxed lg:max-w-xl">
+                Atendimento humanizado em coloproctologia e proctologia em Curitiba.
+              </p>
             </div>
 
             {/* Elegant CTA Section */}

--- a/src/components/sections/LocationsSection.tsx
+++ b/src/components/sections/LocationsSection.tsx
@@ -1,41 +1,22 @@
 import { Calendar, MapPin } from 'lucide-react'
-import { CLINICA_NASSIF, WHATSAPP_MSG_TEXT_ENCODED, WPP_NUMBER_NASSIF } from '@/lib/constants'
 import { LinkButton } from '@/components/ui/LinkButton'
+import { getLocationPath, locationPages } from '@/lib/locations'
 
-const WHATSAPP_SPECTA_NUMBER = '(41) 98773-7829'
-const WHATSAPP_SPECTA_MSG_ENCODED = encodeURIComponent(
-  'Olá! Gostaria de agendar minha colonoscopia com a Dra Ana Luiza'
-)
-
-const getWhatsAppHref = (phone: string, messageEncoded: string) =>
-  `https://wa.me/${phone.replace(/\D/g, '')}/?text=${messageEncoded}`
-
-const locations = [
-  {
-    name: CLINICA_NASSIF.name,
-    address: ['Rua Bruno Filgueira, 489', 'Batel, Curitiba - PR'],
-    phone: CLINICA_NASSIF.phone,
-    whatsapp: CLINICA_NASSIF.wpp,
-    whatsappHref: getWhatsAppHref(WPP_NUMBER_NASSIF, WHATSAPP_MSG_TEXT_ENCODED),
-    buttonText: 'Agende sua consulta agora',
-    ariaLabel: 'Agende sua consulta agora com a Dra. Ana Luiza Moraes Rocha por WhatsApp',
-  },
-  {
-    name: 'Specta Endoscopia Digestiva',
-    address: ['R. Dom Alberto Gonçalves, 311', 'Mercês, Curitiba - PR'],
-    phone: WHATSAPP_SPECTA_NUMBER,
-    whatsapp: WHATSAPP_SPECTA_NUMBER,
-    whatsappHref: getWhatsAppHref(WHATSAPP_SPECTA_NUMBER, WHATSAPP_SPECTA_MSG_ENCODED),
-    buttonText: 'Agende sua colonoscopia',
-    ariaLabel: 'Agende sua colonoscopia com a Dra. Ana Luiza por WhatsApp',
-  },
-] as const
+const locations = locationPages.map((location) => ({
+  slug: location.slug,
+  name: location.name,
+  address: location.addressLines,
+  phone: location.phoneDisplay,
+  whatsapp: location.whatsappDisplay,
+  whatsappHref: location.whatsappHref,
+  buttonText: location.primaryCtaLabel,
+  ariaLabel: `${location.primaryCtaLabel} por WhatsApp`,
+}))
 
 export function LocationsSection() {
   return (
     <section id="atendimento" className="section section-deferred bg-background">
       <div className="max-w-[1760px] mx-auto px-6 sm:px-8 lg:px-10 xl:px-12">
-        {/* Header Section - Enhanced Typography */}
         <div className="mx-auto max-w-4xl text-center mb-16 lg:mb-20 animate-fade-in">
           <h2 className="text-4xl sm:text-5xl lg:text-6xl font-serif font-bold text-primary mb-8">
             Locais de atendimento
@@ -45,11 +26,10 @@ export function LocationsSection() {
           </div>
         </div>
 
-        {/* Location Cards */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-10 xl:gap-12">
           {locations.map((location) => (
             <div
-              key={location.name}
+              key={location.slug}
               className="bg-secondary/10 rounded-3xl p-8 lg:p-10 border border-secondary/20 hover:border-secondary/30 transition-all duration-300 shadow-sm hover:shadow-md h-full flex"
             >
               <div className="flex flex-col gap-6 h-full w-full lg:pl-4 xl:pl-6">
@@ -81,21 +61,33 @@ export function LocationsSection() {
                   </div>
                 </div>
 
-                <LinkButton
-                  href={location.whatsappHref}
-                  external
-                  newTab
-                  variant="primary"
-                  size="lg"
-                  className="mt-auto inline-flex items-center justify-center gap-3 w-full sm:w-[22rem] whitespace-nowrap px-6 py-4 text-sm lg:text-base font-semibold rounded-full shadow-md hover:shadow-lg transform hover:scale-[1.02] transition-all duration-300"
-                  aria-label={location.ariaLabel}
-                >
-                  <Calendar className="size-5" />
-                  {location.buttonText}
-                </LinkButton>
+                <div className="mt-auto flex flex-col gap-4">
+                  <LinkButton
+                    href={location.whatsappHref}
+                    external
+                    newTab
+                    variant="primary"
+                    size="lg"
+                    className="inline-flex items-center justify-center gap-3 w-full sm:w-[22rem] whitespace-nowrap px-6 py-4 text-sm lg:text-base font-semibold rounded-full shadow-md hover:shadow-lg transform hover:scale-[1.02] transition-all duration-300"
+                    aria-label={location.ariaLabel}
+                  >
+                    <Calendar className="size-5" />
+                    {location.buttonText}
+                  </LinkButton>
+
+                  <LinkButton href={getLocationPath(location.slug)} variant="link" size="default">
+                    Ver detalhes deste local
+                  </LinkButton>
+                </div>
               </div>
             </div>
           ))}
+        </div>
+
+        <div className="mt-10 text-center">
+          <LinkButton href="/locais-de-atendimento" variant="outline" size="lg">
+            Ver todos os detalhes dos locais
+          </LinkButton>
         </div>
       </div>
     </section>

--- a/src/components/sections/ServicesSection.tsx
+++ b/src/components/sections/ServicesSection.tsx
@@ -5,19 +5,19 @@ const services = [
     name: 'Hemorroidas',
     description:
       'Quando há dor, sangramento, coceira ou incômodo ao evacuar, é possível que se trate de hemorroidas. Felizmente, hoje existem alternativas modernas e menos invasivas para aliviar esses sintomas com segurança.',
-    href: '/blog/hemorroida-sempre-cirurgica-tratamento',
+    href: '/tratamentos/hemorroidas',
   },
   {
     name: 'Fissura Anal',
     description:
       'Trata-se de uma pequena lesão na borda anal que costuma causar dor intensa durante e após as evacuações. O tratamento precoce pode evitar sofrimento prolongado.',
-    href: '/blog/fissura-anal-tratamento',
+    href: '/tratamentos/toxina-botulinica',
   },
   {
     name: 'Fístula Anal',
     description:
       'Presença de secreção, dor ou abertura próxima ao ânus pode indicar uma fístula. Essa condição exige avaliação especializada, e há diferentes formas de abordagem.',
-    href: '/blog/tratamento-fistulas-anorretais',
+    href: '/tratamentos/cx-fistulas-anorretais',
   },
   {
     name: 'Coceira Anal (Prurido)',
@@ -29,13 +29,13 @@ const services = [
     name: 'HPV Anal',
     description:
       'Lesões causadas pelo papilomavírus humano podem afetar a região anal, tanto interna quanto externamente. O acompanhamento é essencial para tratamento e prevenção de complicações.',
-    href: '/blog/hpv-anal-condilomas-riscos-tratamento-rastreio',
+    href: '/tratamentos/hpv-anal',
   },
   {
     name: 'Cisto Pilonidal',
     description:
       'Se você nota dor ou secreção recorrente na parte inferior da coluna (perto do cóccix), pode ser um cisto pilonidal. Existem opções modernas de tratamento com recuperação mais rápida.',
-    href: '/blog/cisto-pilonidal-cirurgia-laser-quando-operar',
+    href: '/tratamentos/cx-cisto-pilonidal',
   },
   {
     name: 'Constipação Intestinal',
@@ -53,13 +53,13 @@ const services = [
     name: 'Síndrome do Intestino Irritável (SII)',
     description:
       'Sintomas como dor abdominal, gases, inchaço e alterações no ritmo intestinal podem fazer parte da SII. Com acompanhamento adequado, é possível controlar e melhorar muito a qualidade de vida.',
-    href: '/blog/sindrome-intestino-irritavel-sintomas-diagnostico-tratamento',
+    href: '/tratamentos/sindrome-intestino-irritavel',
   },
   {
     name: 'Doenças Inflamatórias Intestinais',
     description:
       'Retocolite Ulcerativa e Doença de Crohn são doenças crônicas que exigem acompanhamento contínuo. O foco é manter a doença sob controle e preservar a qualidade de vida do paciente.',
-    href: '/blog/doencas-inflamatorias-intestinais-acompanhamento',
+    href: '/tratamentos/doencas-inflamatorias-intestinais',
   },
   {
     name: 'Saúde Sexual',
@@ -83,12 +83,13 @@ export function ServicesSection() {
         {/* Header Section - Enhanced Typography */}
         <div className="mx-auto max-w-4xl text-center mb-16 lg:mb-20 animate-fade-in">
           <h2 className="text-3xl sm:text-5xl lg:text-6xl font-serif font-bold text-primary mb-8">
-            Quando procurar uma coloproctologista?
+            Quando procurar uma coloproctologista ou proctologista?
           </h2>
           <div className="text-lg md:text-xl lg:text-2xl leading-relaxed text-secondary font-medium">
             <p>
-              Reconhecer os sinais e sintomas é fundamental para buscar ajuda no momento adequado.
-              Cada queixa merece atenção especializada e cuidadosa.
+              Reconhecer sinais e sintomas ajuda a buscar atendimento no momento certo. Cada queixa
+              merece avaliação especializada em coloproctologia e proctologia, com investigação
+              cuidadosa e plano individualizado.
             </p>
           </div>
         </div>

--- a/src/components/sections/ServicesSection.tsx
+++ b/src/components/sections/ServicesSection.tsx
@@ -11,7 +11,7 @@ const services = [
     name: 'Fissura Anal',
     description:
       'Trata-se de uma pequena lesão na borda anal que costuma causar dor intensa durante e após as evacuações. O tratamento precoce pode evitar sofrimento prolongado.',
-    href: '/tratamentos/toxina-botulinica',
+    href: '/blog/fissura-anal-tratamento',
   },
   {
     name: 'Fístula Anal',

--- a/src/components/sections/ServicesSection.tsx
+++ b/src/components/sections/ServicesSection.tsx
@@ -5,7 +5,7 @@ const services = [
     name: 'Hemorroidas',
     description:
       'Quando há dor, sangramento, coceira ou incômodo ao evacuar, é possível que se trate de hemorroidas. Felizmente, hoje existem alternativas modernas e menos invasivas para aliviar esses sintomas com segurança.',
-    href: '/tratamentos/hemorroidas',
+    href: '/blog/hemorroida-sempre-cirurgica-tratamento',
   },
   {
     name: 'Fissura Anal',
@@ -17,7 +17,7 @@ const services = [
     name: 'Fístula Anal',
     description:
       'Presença de secreção, dor ou abertura próxima ao ânus pode indicar uma fístula. Essa condição exige avaliação especializada, e há diferentes formas de abordagem.',
-    href: '/tratamentos/cx-fistulas-anorretais',
+    href: '/blog/tratamento-fistulas-anorretais',
   },
   {
     name: 'Coceira Anal (Prurido)',
@@ -29,13 +29,13 @@ const services = [
     name: 'HPV Anal',
     description:
       'Lesões causadas pelo papilomavírus humano podem afetar a região anal, tanto interna quanto externamente. O acompanhamento é essencial para tratamento e prevenção de complicações.',
-    href: '/tratamentos/hpv-anal',
+    href: '/blog/hpv-anal-condilomas-riscos-tratamento-rastreio',
   },
   {
     name: 'Cisto Pilonidal',
     description:
       'Se você nota dor ou secreção recorrente na parte inferior da coluna (perto do cóccix), pode ser um cisto pilonidal. Existem opções modernas de tratamento com recuperação mais rápida.',
-    href: '/tratamentos/cx-cisto-pilonidal',
+    href: '/blog/cisto-pilonidal-cirurgia-laser-quando-operar',
   },
   {
     name: 'Constipação Intestinal',
@@ -53,13 +53,13 @@ const services = [
     name: 'Síndrome do Intestino Irritável (SII)',
     description:
       'Sintomas como dor abdominal, gases, inchaço e alterações no ritmo intestinal podem fazer parte da SII. Com acompanhamento adequado, é possível controlar e melhorar muito a qualidade de vida.',
-    href: '/tratamentos/sindrome-intestino-irritavel',
+    href: '/blog/sindrome-intestino-irritavel-sintomas-diagnostico-tratamento',
   },
   {
     name: 'Doenças Inflamatórias Intestinais',
     description:
       'Retocolite Ulcerativa e Doença de Crohn são doenças crônicas que exigem acompanhamento contínuo. O foco é manter a doença sob controle e preservar a qualidade de vida do paciente.',
-    href: '/tratamentos/doencas-inflamatorias-intestinais',
+    href: '/blog/doencas-inflamatorias-intestinais-acompanhamento',
   },
   {
     name: 'Saúde Sexual',

--- a/src/components/sections/TreatmentsSection.tsx
+++ b/src/components/sections/TreatmentsSection.tsx
@@ -51,8 +51,8 @@ export function TreatmentsSection() {
           </h2>
           <div className="text-xl lg:text-2xl leading-relaxed text-secondary font-medium space-y-4">
             <p>
-              Nossa consulta é individualizada e detalhada e busca um
-              entendimento completo sobre você e seu problema.
+              Nossa consulta em coloproctologia e proctologia é individualizada, detalhada e busca
+              um entendimento completo sobre você e seu problema.
             </p>
             <p>
               Para nós, cuidar vai além do diagnóstico. Adaptamos cada

--- a/src/components/ui/Footer.tsx
+++ b/src/components/ui/Footer.tsx
@@ -49,6 +49,12 @@ export function Footer() {
                 Sobre
               </Link>
               <Link
+                href="/locais-de-atendimento"
+                className="text-background/70 hover:text-background text-sm font-medium transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-background/50 rounded-sm"
+              >
+                Locais
+              </Link>
+              <Link
                 href="/tratamentos"
                 className="text-background/70 hover:text-background text-sm font-medium transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-background/50 rounded-sm"
               >

--- a/src/components/ui/RelatedBlogCard.tsx
+++ b/src/components/ui/RelatedBlogCard.tsx
@@ -29,12 +29,12 @@ export function RelatedBlogCard({ treatmentSlug }: RelatedBlogCardProps) {
           {relatedPosts.map((post) => (
             <article
               key={post.slug}
-              className="rounded-2xl border border-secondary/15 bg-background/80 p-5"
+              className="flex flex-col rounded-2xl border border-secondary/15 bg-background/80 p-5"
             >
               <h3 className="text-lg sm:text-xl font-serif font-bold text-primary mb-3 leading-tight">
                 {post.title}
               </h3>
-              <p className="text-sm sm:text-base text-secondary leading-relaxed mb-5">
+              <p className="flex-1 text-sm sm:text-base text-secondary leading-relaxed mb-5">
                 {post.excerpt}
               </p>
               <LinkButton href={`/blog/${post.slug}`} variant="outline" size="default">

--- a/src/components/ui/RelatedPostsSection.tsx
+++ b/src/components/ui/RelatedPostsSection.tsx
@@ -1,5 +1,5 @@
-import Link from 'next/link'
 import { Badge } from '@/components/ui/Badge'
+import { TreatmentCard } from '@/components/ui/TreatmentCard'
 import type { BlogPost } from '@/lib/blog'
 
 interface RelatedPostsSectionProps {
@@ -21,26 +21,13 @@ export function RelatedPostsSection({ posts }: RelatedPostsSectionProps) {
         </Badge>
         <div className="grid gap-4 md:grid-cols-2">
           {relatedPosts.map((post) => (
-            <article
+            <TreatmentCard
               key={post.slug}
-              className="rounded-2xl border border-secondary/15 bg-background/80 p-5"
-            >
-              <h3 className="text-lg sm:text-xl font-serif font-bold text-primary mb-3 leading-tight">
-                <Link href={`/blog/${post.slug}`} className="hover:text-primary/80 transition-colors">
-                  {post.title}
-                </Link>
-              </h3>
-              <p className="text-sm sm:text-base text-secondary leading-relaxed mb-4">
-                {post.excerpt}
-              </p>
-              <Link
-                href={`/blog/${post.slug}`}
-                className="inline-flex items-center gap-1 text-primary font-semibold hover:text-primary/80 transition-colors"
-              >
-                Ler artigo
-                <span aria-hidden="true">→</span>
-              </Link>
-            </article>
+              href={`/blog/${post.slug}`}
+              title={post.title}
+              description={post.excerpt}
+              variant="detailed"
+            />
           ))}
         </div>
       </div>

--- a/src/components/ui/RelatedPostsSection.tsx
+++ b/src/components/ui/RelatedPostsSection.tsx
@@ -1,0 +1,49 @@
+import Link from 'next/link'
+import { Badge } from '@/components/ui/Badge'
+import type { BlogPost } from '@/lib/blog'
+
+interface RelatedPostsSectionProps {
+  posts: BlogPost[]
+}
+
+export function RelatedPostsSection({ posts }: RelatedPostsSectionProps) {
+  const relatedPosts = posts.slice(0, 2)
+
+  if (relatedPosts.length === 0) {
+    return null
+  }
+
+  return (
+    <aside className="not-prose my-10">
+      <div className="rounded-3xl border border-secondary/20 bg-primary/5 p-6 sm:p-8">
+        <Badge variant="primary" className="mb-4">
+          Continue lendo
+        </Badge>
+        <div className="grid gap-4 md:grid-cols-2">
+          {relatedPosts.map((post) => (
+            <article
+              key={post.slug}
+              className="rounded-2xl border border-secondary/15 bg-background/80 p-5"
+            >
+              <h3 className="text-lg sm:text-xl font-serif font-bold text-primary mb-3 leading-tight">
+                <Link href={`/blog/${post.slug}`} className="hover:text-primary/80 transition-colors">
+                  {post.title}
+                </Link>
+              </h3>
+              <p className="text-sm sm:text-base text-secondary leading-relaxed mb-4">
+                {post.excerpt}
+              </p>
+              <Link
+                href={`/blog/${post.slug}`}
+                className="inline-flex items-center gap-1 text-primary font-semibold hover:text-primary/80 transition-colors"
+              >
+                Ler artigo
+                <span aria-hidden="true">→</span>
+              </Link>
+            </article>
+          ))}
+        </div>
+      </div>
+    </aside>
+  )
+}

--- a/src/components/ui/RelatedTreatmentsSection.tsx
+++ b/src/components/ui/RelatedTreatmentsSection.tsx
@@ -1,5 +1,5 @@
 import { Badge } from '@/components/ui/Badge'
-import { LinkButton } from '@/components/ui/LinkButton'
+import { TreatmentCard } from '@/components/ui/TreatmentCard'
 import { getTreatmentLinkBySlug } from '@/lib/content-relationships'
 
 interface RelatedTreatmentsSectionProps {
@@ -24,20 +24,13 @@ export function RelatedTreatmentsSection({ treatmentSlugs }: RelatedTreatmentsSe
         </Badge>
         <div className="grid gap-4 md:grid-cols-2">
           {relatedTreatments.map((treatment) => (
-            <article
+            <TreatmentCard
               key={treatment.slug}
-              className="rounded-2xl border border-secondary/15 bg-background/80 p-5"
-            >
-              <h3 className="text-lg sm:text-xl font-serif font-bold text-primary mb-3 leading-tight">
-                {treatment.title}
-              </h3>
-              <p className="text-sm sm:text-base text-secondary leading-relaxed mb-5">
-                {treatment.description}
-              </p>
-              <LinkButton href={treatment.href} variant="outline" size="default">
-                Ver página de tratamento
-              </LinkButton>
-            </article>
+              href={treatment.href}
+              title={treatment.title}
+              description={treatment.description}
+              variant="detailed"
+            />
           ))}
         </div>
       </div>

--- a/src/components/ui/RelatedTreatmentsSection.tsx
+++ b/src/components/ui/RelatedTreatmentsSection.tsx
@@ -1,21 +1,18 @@
 import { Badge } from '@/components/ui/Badge'
 import { LinkButton } from '@/components/ui/LinkButton'
-import { getAllPosts } from '@/lib/blog'
-import { getRelatedPostsForTreatment } from '@/lib/content-relationships'
-import type { TreatmentSlug } from '@/lib/treatment-images'
+import { getTreatmentLinkBySlug } from '@/lib/content-relationships'
 
-interface RelatedBlogCardProps {
-  treatmentSlug: string
+interface RelatedTreatmentsSectionProps {
+  treatmentSlugs: string[]
 }
 
-export function RelatedBlogCard({ treatmentSlug }: RelatedBlogCardProps) {
-  const relatedPosts = getRelatedPostsForTreatment(
-    treatmentSlug as TreatmentSlug,
-    getAllPosts(),
-    4
-  )
+export function RelatedTreatmentsSection({ treatmentSlugs }: RelatedTreatmentsSectionProps) {
+  const relatedTreatments = treatmentSlugs
+    .map((slug) => getTreatmentLinkBySlug(slug))
+    .filter((treatment): treatment is NonNullable<typeof treatment> => Boolean(treatment))
+    .slice(0, 2)
 
-  if (relatedPosts.length === 0) {
+  if (relatedTreatments.length === 0) {
     return null
   }
 
@@ -23,22 +20,22 @@ export function RelatedBlogCard({ treatmentSlug }: RelatedBlogCardProps) {
     <aside className="not-prose my-10">
       <div className="rounded-3xl border border-secondary/20 bg-secondary/10 p-6 sm:p-8">
         <Badge variant="secondary" className="mb-4">
-          Leitura relacionada
+          Tratamentos relacionados
         </Badge>
         <div className="grid gap-4 md:grid-cols-2">
-          {relatedPosts.map((post) => (
+          {relatedTreatments.map((treatment) => (
             <article
-              key={post.slug}
+              key={treatment.slug}
               className="rounded-2xl border border-secondary/15 bg-background/80 p-5"
             >
               <h3 className="text-lg sm:text-xl font-serif font-bold text-primary mb-3 leading-tight">
-                {post.title}
+                {treatment.title}
               </h3>
               <p className="text-sm sm:text-base text-secondary leading-relaxed mb-5">
-                {post.excerpt}
+                {treatment.description}
               </p>
-              <LinkButton href={`/blog/${post.slug}`} variant="outline" size="default">
-                Ver artigo no blog
+              <LinkButton href={treatment.href} variant="outline" size="default">
+                Ver página de tratamento
               </LinkButton>
             </article>
           ))}

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import matter from 'gray-matter'
 import type { FAQPage, Question, Answer, Thing } from 'schema-dts'
 import { WEBSITE_URL, SITE_NAME, URL_INSTAGRAM, URL_LINKEDIN } from '@/lib/constants'
+import type { TreatmentSlug } from '@/lib/treatment-images'
 
 /**
  * Target audience enum for blog posts
@@ -91,6 +92,8 @@ export interface BlogPostMeta {
   featured?: boolean
   order?: number
   faqs?: FAQItem[]
+  relatedTreatments?: TreatmentSlug[]
+  relatedPosts?: string[]
 }
 
 /**

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -160,3 +160,34 @@ export const CLINICA_NASSIF = {
   /** Opening hours formatted for display */
   openingHoursDisplay: 'Segunda a Sexta: 08:00 - 19:30',
 } as const
+
+// =============================================================================
+// Specta Endoscopia Digestiva Information
+// =============================================================================
+
+export const SPECTA_ENDOSCOPIA = {
+  /** Clinic name */
+  name: 'Specta Endoscopia Digestiva',
+
+  /** Street address */
+  address: 'R. Dom Alberto Gonçalves, 311',
+
+  /** Neighborhood */
+  neighborhood: 'Mercês',
+
+  /** City */
+  city: 'Curitiba',
+
+  /** State abbreviation */
+  state: 'PR',
+
+  /** State full name */
+  stateFull: 'Paraná',
+
+  /** Contact phone used on the website */
+  phone: '(41) 98773-7829',
+
+  /** Google Maps search URL */
+  maps:
+    'https://maps.google.com/?q=R.%20Dom%20Alberto%20Gon%C3%A7alves%2C%20311%2C%20Merc%C3%AAs%2C%20Curitiba%20-%20PR',
+} as const

--- a/src/lib/content-relationships.ts
+++ b/src/lib/content-relationships.ts
@@ -1,0 +1,265 @@
+import type { BlogPost } from '@/lib/blog'
+import type { TreatmentSlug } from '@/lib/treatment-images'
+
+export interface TreatmentLinkEntry {
+  slug: TreatmentSlug
+  href: string
+  title: string
+  description: string
+}
+
+const buildRelationshipMap = (slugs: string[], relatedTreatments: TreatmentSlug[]) =>
+  Object.fromEntries(slugs.map((slug) => [slug, relatedTreatments]))
+
+export const TREATMENT_LINK_BY_SLUG: Record<TreatmentSlug, TreatmentLinkEntry> = {
+  'cx-laser': {
+    slug: 'cx-laser',
+    href: '/tratamentos/cx-laser',
+    title: 'Cirurgia a laser proctológica',
+    description:
+      'Veja quando o laser pode ser considerado em hemorroidas, fissuras e outras doenças orificiais.',
+  },
+  hemorroidas: {
+    slug: 'hemorroidas',
+    href: '/tratamentos/hemorroidas',
+    title: 'Tratamento de hemorroidas',
+    description:
+      'Entenda opções como ligadura elástica, escleroterapia, hemorroidectomia, laser e THD.',
+  },
+  'cx-fistulas-anorretais': {
+    slug: 'cx-fistulas-anorretais',
+    href: '/tratamentos/cx-fistulas-anorretais',
+    title: 'Cirurgias para fístulas anorretais',
+    description:
+      'Compare fistulotomia, seton, LIFT, retalho mucoso e técnicas combinadas para fístula anal.',
+  },
+  'toxina-botulinica': {
+    slug: 'toxina-botulinica',
+    href: '/tratamentos/toxina-botulinica',
+    title: 'Toxina botulínica para fissura anal',
+    description:
+      'Saiba quando o botox anal pode ser considerado para fissura anal crônica e dor anal persistente.',
+  },
+  'rastreio-cancer-anal': {
+    slug: 'rastreio-cancer-anal',
+    href: '/tratamentos/rastreio-cancer-anal',
+    title: 'Rastreio de câncer anal e HPV',
+    description:
+      'Conheça citologia anal, anuscopia de alta resolução e critérios de rastreio em grupos de risco.',
+  },
+  'hpv-anal': {
+    slug: 'hpv-anal',
+    href: '/tratamentos/hpv-anal',
+    title: 'Tratamento de HPV anal',
+    description:
+      'Veja como é feita a avaliação, o tratamento de condilomas e o acompanhamento das lesões por HPV.',
+  },
+  'cx-cisto-pilonidal': {
+    slug: 'cx-cisto-pilonidal',
+    href: '/tratamentos/cx-cisto-pilonidal',
+    title: 'Cirurgia de cisto pilonidal',
+    description:
+      'Entenda quando operar, como avaliar recorrência e em quais casos o laser pode ajudar.',
+  },
+  'doencas-inflamatorias-intestinais': {
+    slug: 'doencas-inflamatorias-intestinais',
+    href: '/tratamentos/doencas-inflamatorias-intestinais',
+    title: 'Doença de Crohn e retocolite',
+    description:
+      'Acompanhamento especializado para doenças inflamatórias intestinais, remissão e prevenção de complicações.',
+  },
+  'sindrome-intestino-irritavel': {
+    slug: 'sindrome-intestino-irritavel',
+    href: '/tratamentos/sindrome-intestino-irritavel',
+    title: 'Síndrome do intestino irritável',
+    description:
+      'Investigação e acompanhamento de dor abdominal, distensão, constipação e diarreia funcionais.',
+  },
+}
+
+const DEFAULT_RELATED_TREATMENTS_BY_POST_SLUG: Record<string, TreatmentSlug[]> = {
+  ...buildRelationshipMap(
+    [
+      'hemorroida-sempre-cirurgica-tratamento',
+      'hemorroida-sempre-precisa-cirurgia',
+      'hemorroida-quanto-tempo-dura-quando-procurar',
+      'sangue-papel-higienico-sempre-hemorroida',
+      'ligadura-elastica-hemorroidas-doi-recuperacao',
+      'thd-hemorroidas-quando-indicado',
+    ],
+    ['hemorroidas']
+  ),
+  ...buildRelationshipMap(
+    [
+      'fissura-anal-tratamento',
+      'fissura-anal-toxina-botulinica-tratamento',
+      'fissura-anal-quando-cirurgia-indicada',
+      'dor-ao-evacuar-causas-tratamento',
+      'proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento',
+      'primeira-consulta-proctologista-curitiba-o-que-esperar',
+    ],
+    ['toxina-botulinica', 'cx-laser']
+  ),
+  ...buildRelationshipMap(
+    [
+      'tratamento-fistulas-anorretais',
+      'proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento',
+    ],
+    ['cx-fistulas-anorretais']
+  ),
+  ...buildRelationshipMap(
+    [
+      'hpv-anal-condilomas-riscos-tratamento-rastreio',
+      'cancer-canal-anal-rastreio-hpv-quem-deve-se-preocupar',
+      'saude-sexual-cuidado-informacao-bem-estar',
+      'coceira-anal-quando-procurar-coloproctologista-curitiba',
+      'coceira-anus-causas-tratamento',
+      'proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento',
+    ],
+    ['hpv-anal', 'rastreio-cancer-anal']
+  ),
+  ...buildRelationshipMap(
+    [
+      'cisto-pilonidal-cirurgia-laser-quando-operar',
+      'cisto-pilonidal-precisa-cirurgia',
+      'cisto-pilonidal-cisto-sacrococcigeo-mesma-coisa',
+    ],
+    ['cx-cisto-pilonidal', 'cx-laser']
+  ),
+  ...buildRelationshipMap(
+    [
+      'constipacao-intestinal-cronica-causas-tratamento',
+      'diarreia-cronica-tratamento',
+      'sindrome-intestino-irritavel-sintomas-diagnostico-tratamento',
+      'alimentacao-e-saude-intestinal',
+      'alimentacao-fibras-saude-intestinal',
+      'disbiose-sibo-tratamento',
+      'disturbios-assoalho-pelvico-funcionamento-intestino',
+      'intestino-preso-muitos-dias-perigoso',
+      'por-que-meus-sintomas-nunca-melhoram',
+      'proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento',
+      'primeira-consulta-proctologista-curitiba-o-que-esperar',
+    ],
+    ['sindrome-intestino-irritavel']
+  ),
+  ...buildRelationshipMap(
+    [
+      'doencas-inflamatorias-intestinais-acompanhamento',
+      'diarreia-cronica-tratamento',
+      'sangue-nas-fezes-quando-procurar-coloproctologista',
+      'quando-intestino-da-sinais-de-alerta-coloproctologista-curitiba',
+      'cancer-colorretal-rastreio-prevencao-diagnostico-precoce',
+      'por-que-meus-sintomas-nunca-melhoram',
+      'primeira-consulta-proctologista-curitiba-o-que-esperar',
+    ],
+    ['doencas-inflamatorias-intestinais']
+  ),
+  'plicoma-anal-cirurgia-laser': ['cx-laser'],
+  'plicoma-anal-vale-a-pena-retirar': ['cx-laser'],
+  'quando-procurar-coloproctologista-curitiba': ['hemorroidas', 'sindrome-intestino-irritavel'],
+  'quando-intestino-da-sinais-de-alerta-coloproctologista-curitiba': [
+    'hemorroidas',
+    'doencas-inflamatorias-intestinais',
+  ],
+  'sangue-nas-fezes-quando-procurar-coloproctologista': [
+    'hemorroidas',
+    'doencas-inflamatorias-intestinais',
+  ],
+  'sinto-vergonha-procurar-coloproctologista-isso-e-normal': [
+    'hemorroidas',
+    'sindrome-intestino-irritavel',
+  ],
+  'o-que-muda-acompanhamento-especializado-coloproctologista-curitiba': [
+    'doencas-inflamatorias-intestinais',
+    'sindrome-intestino-irritavel',
+  ],
+}
+
+const DEFAULT_RELATED_POSTS_BY_POST_SLUG: Record<string, string[]> = {
+  'proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento': [
+    'quando-procurar-coloproctologista-curitiba',
+    'primeira-consulta-proctologista-curitiba-o-que-esperar',
+  ],
+  'primeira-consulta-proctologista-curitiba-o-que-esperar': [
+    'proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento',
+    'quando-procurar-coloproctologista-curitiba',
+  ],
+  'ligadura-elastica-hemorroidas-doi-recuperacao': [
+    'hemorroida-sempre-cirurgica-tratamento',
+    'thd-hemorroidas-quando-indicado',
+  ],
+  'thd-hemorroidas-quando-indicado': [
+    'ligadura-elastica-hemorroidas-doi-recuperacao',
+    'hemorroida-sempre-cirurgica-tratamento',
+  ],
+  'cisto-pilonidal-cisto-sacrococcigeo-mesma-coisa': [
+    'cisto-pilonidal-cirurgia-laser-quando-operar',
+    'cisto-pilonidal-precisa-cirurgia',
+  ],
+}
+
+const unique = <T,>(values: T[]) => Array.from(new Set(values))
+
+export function getTreatmentLinkBySlug(slug: string): TreatmentLinkEntry | undefined {
+  return TREATMENT_LINK_BY_SLUG[slug as TreatmentSlug]
+}
+
+export function getResolvedRelatedTreatmentSlugs(
+  post: Pick<BlogPost, 'slug' | 'relatedTreatments'>
+): TreatmentSlug[] {
+  if (post.relatedTreatments && post.relatedTreatments.length > 0) {
+    return unique(post.relatedTreatments)
+  }
+
+  return DEFAULT_RELATED_TREATMENTS_BY_POST_SLUG[post.slug] || []
+}
+
+export function getResolvedRelatedPostSlugs(
+  post: Pick<BlogPost, 'slug' | 'relatedPosts' | 'relatedTreatments'>,
+  allPosts: BlogPost[],
+  limit = 2
+): string[] {
+  if (post.relatedPosts && post.relatedPosts.length > 0) {
+    return unique(post.relatedPosts.filter((slug) => slug !== post.slug)).slice(0, limit)
+  }
+
+  const defaultRelatedPosts = DEFAULT_RELATED_POSTS_BY_POST_SLUG[post.slug]
+  if (defaultRelatedPosts && defaultRelatedPosts.length > 0) {
+    return unique(defaultRelatedPosts.filter((slug) => slug !== post.slug)).slice(0, limit)
+  }
+
+  const relatedTreatmentSlugs = getResolvedRelatedTreatmentSlugs(post)
+
+  if (relatedTreatmentSlugs.length === 0) {
+    return []
+  }
+
+  return allPosts
+    .filter((candidate) => candidate.slug !== post.slug)
+    .filter((candidate) => {
+      const candidateTreatmentSlugs = getResolvedRelatedTreatmentSlugs(candidate)
+      return candidateTreatmentSlugs.some((slug) => relatedTreatmentSlugs.includes(slug))
+    })
+    .map((candidate) => candidate.slug)
+    .slice(0, limit)
+}
+
+export function getRelatedPostsForTreatment(
+  treatmentSlug: TreatmentSlug,
+  allPosts: BlogPost[],
+  limit = 4
+): BlogPost[] {
+  return allPosts
+    .filter((post) => getResolvedRelatedTreatmentSlugs(post).includes(treatmentSlug))
+    .sort((left, right) => {
+      const leftFeatured = left.featured ? 1 : 0
+      const rightFeatured = right.featured ? 1 : 0
+
+      if (leftFeatured !== rightFeatured) {
+        return rightFeatured - leftFeatured
+      }
+
+      return right.publishDate.localeCompare(left.publishDate)
+    })
+    .slice(0, limit)
+}

--- a/src/lib/faq-schema.ts
+++ b/src/lib/faq-schema.ts
@@ -1,4 +1,8 @@
-import { WPP_NUMBER_NASSIF_FORMATTED, CLINICA_NASSIF } from './constants'
+import {
+  CLINICA_NASSIF,
+  SPECTA_ENDOSCOPIA,
+  WPP_NUMBER_NASSIF_FORMATTED,
+} from './constants'
 
 export const faqSchema = {
   '@context': 'https://schema.org',
@@ -30,10 +34,10 @@ export const faqSchema = {
     },
     {
       '@type': 'Question',
-      name: 'Onde fica o consultório em Curitiba?',
+      name: 'Onde a Dra. Ana Luiza atende em Curitiba?',
       acceptedAnswer: {
         '@type': 'Answer',
-        text: `O consultório fica na ${CLINICA_NASSIF.name}, localizada na ${CLINICA_NASSIF.address}, no bairro ${CLINICA_NASSIF.neighborhood}, em ${CLINICA_NASSIF.city} - ${CLINICA_NASSIF.state}.`,
+        text: `As consultas em coloproctologia acontecem na ${CLINICA_NASSIF.name}, localizada na ${CLINICA_NASSIF.address}, no bairro ${CLINICA_NASSIF.neighborhood}, em ${CLINICA_NASSIF.city} - ${CLINICA_NASSIF.state}. Quando a colonoscopia é indicada, o site também informa a ${SPECTA_ENDOSCOPIA.name}, na ${SPECTA_ENDOSCOPIA.address}, no bairro ${SPECTA_ENDOSCOPIA.neighborhood}.`,
       },
     },
     {

--- a/src/lib/locations.ts
+++ b/src/lib/locations.ts
@@ -1,0 +1,406 @@
+import {
+  CLINICA_NASSIF,
+  DR_NAME,
+  SPECTA_ENDOSCOPIA,
+  WEBSITE_URL,
+  WHATSAPP_MSG_TEXT_ENCODED,
+  WPP_NUMBER_NASSIF,
+} from './constants'
+import { generateBreadcrumbSchema, type FAQItem } from './seo-schemas'
+
+export const LOCATIONS_BASE_PATH = '/locais-de-atendimento'
+
+const WHATSAPP_COLONOSCOPY_TEXT = encodeURIComponent(
+  'Olá! Gostaria de agendar minha colonoscopia com a Dra. Ana Luiza Rocha.'
+)
+
+const createWhatsAppHref = (phone: string, encodedText: string) =>
+  `https://wa.me/${phone.replace(/\D/g, '')}/?text=${encodedText}`
+
+const createPhoneHref = (phone: string) => `tel:${phone.replace(/\D/g, '')}`
+
+type RelatedLink = {
+  href: string
+  label: string
+}
+
+type LocationService = {
+  name: string
+  description: string
+}
+
+export interface LocationPageData {
+  slug: string
+  name: string
+  shortName: string
+  badgeLabel: string
+  pageTitle: string
+  metaTitle: string
+  metaDescription: string
+  summary: string
+  cardDescription: string
+  visibleRelationshipText: string
+  addressLines: [string, string]
+  streetAddress: string
+  neighborhood: string
+  city: string
+  state: string
+  postalCode?: string
+  phoneDisplay: string
+  phoneHref: string
+  whatsappDisplay: string
+  whatsappHref: string
+  mapUrl: string
+  mapLabel: string
+  primaryCtaLabel: string
+  schedulingDescription: string
+  servicesTitle: string
+  services: string[]
+  overviewParagraphs: string[]
+  practicalInfo: string[]
+  relatedTreatments: RelatedLink[]
+  relatedArticles?: RelatedLink[]
+  faq: FAQItem[]
+  schemaDescription: string
+  schemaServices: LocationService[]
+  clinicWebsite?: string
+}
+
+export const locationPages: LocationPageData[] = [
+  {
+    slug: 'clinica-nassif',
+    name: CLINICA_NASSIF.name,
+    shortName: 'Clínica Nassif',
+    badgeLabel: 'Consulta em coloproctologia',
+    pageTitle: 'Clínica Nassif',
+    metaTitle: 'Clínica Nassif | Onde a Dra. Ana Luiza Rocha atende em Curitiba',
+    metaDescription:
+      'Consultas em coloproctologia com a Dra. Ana Luiza Rocha na Clínica Nassif, no Batel, em Curitiba. Veja endereço, como agendar e tratamentos relacionados.',
+    summary: 'Consultas, retornos e acompanhamento no Batel.',
+    cardDescription:
+      'Local indicado para consulta inicial, retorno e definição do plano de cuidado em coloproctologia.',
+    visibleRelationshipText:
+      'A Dra. Ana Luiza Rocha atende na Clínica Nassif para consultas, retornos e acompanhamento em coloproctologia.',
+    addressLines: ['Rua Bruno Filgueira, 489', 'Batel, Curitiba - PR'],
+    streetAddress: CLINICA_NASSIF.address,
+    neighborhood: CLINICA_NASSIF.neighborhood,
+    city: CLINICA_NASSIF.city,
+    state: CLINICA_NASSIF.state,
+    postalCode: CLINICA_NASSIF.cep,
+    phoneDisplay: CLINICA_NASSIF.phone,
+    phoneHref: createPhoneHref(CLINICA_NASSIF.phoneFormatted),
+    whatsappDisplay: CLINICA_NASSIF.wpp,
+    whatsappHref: createWhatsAppHref(WPP_NUMBER_NASSIF, WHATSAPP_MSG_TEXT_ENCODED),
+    mapUrl: CLINICA_NASSIF.maps,
+    mapLabel: 'Ver rota para a Clínica Nassif',
+    primaryCtaLabel: 'Agendar consulta na Clínica Nassif',
+    schedulingDescription:
+      'Este é o principal local para consulta, reavaliação, retorno e organização do cuidado clínico ou cirúrgico com a Dra. Ana Luiza.',
+    servicesTitle: 'Quando este local faz mais sentido',
+    services: [
+      'Consulta inicial para avaliar sintomas, histórico e exames já realizados.',
+      'Retornos e seguimento de tratamentos clínicos, ambulatoriais e cirúrgicos.',
+      'Discussão de condutas para hemorroidas, fissura anal, fístulas, HPV anal e doenças inflamatórias intestinais.',
+      'Orientação sobre exames e encaminhamento para procedimentos quando indicados.',
+    ],
+    overviewParagraphs: [
+      'A Clínica Nassif é a principal referência para consulta com a Dra. Ana Luiza em Curitiba. É aqui que acontece a avaliação inicial, a revisão de exames e o acompanhamento ao longo do tratamento.',
+      'Na consulta, a proposta é entender a queixa com calma, revisar hipóteses diagnósticas e definir o próximo passo do cuidado de forma individualizada.',
+    ],
+    practicalInfo: [
+      'O endereço fica no Batel, bairro de fácil acesso para quem busca atendimento em Curitiba.',
+      'Se você já tiver exames, laudos ou receitas recentes, vale levá-los para a consulta.',
+      'O agendamento pode ser feito pelo WhatsApp da equipe ou pelo telefone da clínica.',
+    ],
+    relatedTreatments: [
+      { href: '/tratamentos/hemorroidas', label: 'Tratamento de hemorroidas' },
+      { href: '/tratamentos/toxina-botulinica', label: 'Toxina botulínica para fissura anal' },
+      { href: '/tratamentos/cx-laser', label: 'Cirurgias a laser em coloproctologia' },
+    ],
+    faq: [
+      {
+        question: 'A primeira consulta com a Dra. Ana Luiza acontece na Clínica Nassif?',
+        answer:
+          'Sim. A Clínica Nassif é um dos locais indicados para consulta inicial, retorno e organização do plano de cuidado em coloproctologia.',
+      },
+      {
+        question: 'Posso agendar retorno neste mesmo local?',
+        answer:
+          'Sim. O acompanhamento clínico e o seguimento após tratamentos podem ser organizados pela equipe da Clínica Nassif.',
+      },
+      {
+        question: 'Quais sintomas costumam motivar consulta neste local?',
+        answer:
+          'Queixas como dor ao evacuar, sangramento, coceira anal, hemorroidas, fissuras, alterações do hábito intestinal e necessidade de acompanhamento especializado costumam ser avaliadas em consulta.',
+      },
+    ],
+    schemaDescription:
+      'Clínica em Curitiba onde a Dra. Ana Luiza Rocha realiza consultas, retornos e acompanhamento em coloproctologia.',
+    schemaServices: [
+      {
+        name: 'Consulta em coloproctologia',
+        description:
+          'Avaliação inicial, revisão de sintomas e definição de conduta com a Dra. Ana Luiza Rocha.',
+      },
+      {
+        name: 'Retorno e acompanhamento',
+        description:
+          'Seguimento clínico e pós-tratamento em doenças do intestino, reto e ânus.',
+      },
+    ],
+    clinicWebsite: CLINICA_NASSIF.website,
+  },
+  {
+    slug: 'specta-endoscopia-digestiva',
+    name: SPECTA_ENDOSCOPIA.name,
+    shortName: 'Specta Endoscopia Digestiva',
+    badgeLabel: 'Colonoscopia quando indicada',
+    pageTitle: 'Specta Endoscopia Digestiva',
+    metaTitle: 'Specta Endoscopia Digestiva | Atendimento com Dra. Ana Luiza Rocha',
+    metaDescription:
+      'Colonoscopia com a Dra. Ana Luiza Rocha na Specta Endoscopia Digestiva, em Curitiba. Veja endereço, orientações de agendamento e contexto do exame.',
+    summary:
+      'Local relacionado à colonoscopia no bairro Mercês.',
+    cardDescription:
+      'Referência para colonoscopia com a Dra. Ana Luiza quando o exame entra na investigação ou no rastreio.',
+    visibleRelationshipText:
+      'A Dra. Ana Luiza Rocha realiza colonoscopia na Specta quando o exame é indicado na avaliação do paciente.',
+    addressLines: ['R. Dom Alberto Gonçalves, 311', 'Mercês, Curitiba - PR'],
+    streetAddress: SPECTA_ENDOSCOPIA.address,
+    neighborhood: SPECTA_ENDOSCOPIA.neighborhood,
+    city: SPECTA_ENDOSCOPIA.city,
+    state: SPECTA_ENDOSCOPIA.state,
+    phoneDisplay: SPECTA_ENDOSCOPIA.phone,
+    phoneHref: createPhoneHref(SPECTA_ENDOSCOPIA.phone),
+    whatsappDisplay: SPECTA_ENDOSCOPIA.phone,
+    whatsappHref: createWhatsAppHref(SPECTA_ENDOSCOPIA.phone, WHATSAPP_COLONOSCOPY_TEXT),
+    mapUrl: SPECTA_ENDOSCOPIA.maps,
+    mapLabel: 'Ver rota para a Specta Endoscopia Digestiva',
+    primaryCtaLabel: 'Agendar colonoscopia',
+    schedulingDescription:
+      'Este local é usado quando a colonoscopia faz parte da investigação de sintomas ou do rastreio recomendado pela Dra. Ana Luiza.',
+    servicesTitle: 'Quando este local costuma ser indicado',
+    services: [
+      'Colonoscopia solicitada após consulta, conforme sintomas, idade, histórico e fatores de risco.',
+      'Exame no contexto de investigação de sangramento, alteração intestinal ou necessidade de rastreio.',
+      'Complemento da avaliação quando o plano de cuidado exige confirmação diagnóstica por exame.',
+    ],
+    overviewParagraphs: [
+      'A Specta Endoscopia Digestiva é o local de referência quando a Dra. Ana Luiza indica colonoscopia como parte da investigação ou da prevenção. O foco aqui é o exame, e não a consulta geral.',
+      'Na prática, a consulta ajuda a definir se a colonoscopia faz sentido. Quando há indicação, o exame é organizado no local apropriado, com orientação específica para esse momento do cuidado.',
+    ],
+    practicalInfo: [
+      'O endereço fica no bairro Mercês, em Curitiba.',
+      'A equipe informa no agendamento como funciona o preparo e os passos práticos antes do exame.',
+      'Quando houver consulta prévia, vale manter os laudos e orientações médicas em mãos para facilitar a organização do exame.',
+    ],
+    relatedTreatments: [
+      {
+        href: '/tratamentos/doencas-inflamatorias-intestinais',
+        label: 'Acompanhamento de doenças inflamatórias intestinais',
+      },
+      {
+        href: '/tratamentos/sindrome-intestino-irritavel',
+        label: 'Síndrome do intestino irritável',
+      },
+      { href: '/tratamentos', label: 'Ver a visão geral dos tratamentos' },
+    ],
+    relatedArticles: [
+      {
+        href: '/blog/cancer-colorretal-rastreio-prevencao-diagnostico-precoce',
+        label: 'Quando a colonoscopia entra no rastreio do câncer colorretal',
+      },
+      {
+        href: '/blog/sangue-nas-fezes-quando-procurar-coloproctologista',
+        label: 'Sangue nas fezes: quando investigar',
+      },
+    ],
+    faq: [
+      {
+        question: 'A Specta é o local das consultas em coloproctologia?',
+        answer:
+          'Não. A Specta aparece no site como o local relacionado à colonoscopia quando esse exame é indicado. A consulta clínica e o acompanhamento geral são organizados em contexto próprio.',
+      },
+      {
+        question: 'Toda pessoa atendida pela Dra. Ana precisa de colonoscopia?',
+        answer:
+          'Não. A colonoscopia é indicada de forma individualizada, de acordo com sintomas, idade, histórico e objetivo da investigação.',
+      },
+      {
+        question: 'Como agendar a colonoscopia na Specta?',
+        answer:
+          'O agendamento pode ser iniciado pelo contato exibido nesta página. A equipe orienta os próximos passos, inclusive preparo e horário quando o exame é confirmado.',
+      },
+    ],
+    schemaDescription:
+      'Local em Curitiba relacionado à colonoscopia com a Dra. Ana Luiza Rocha quando o exame é indicado na investigação ou prevenção.',
+    schemaServices: [
+      {
+        name: 'Colonoscopia',
+        description:
+          'Exame endoscópico realizado com a Dra. Ana Luiza Rocha quando há indicação clínica ou preventiva.',
+      },
+    ],
+  },
+]
+
+export function getLocationBySlug(slug: string) {
+  return locationPages.find((location) => location.slug === slug)
+}
+
+export function getLocationPath(slug: string) {
+  return `${LOCATIONS_BASE_PATH}/${slug}`
+}
+
+function getLocationSchemaId(slug: string) {
+  return `${WEBSITE_URL}${getLocationPath(slug)}#place`
+}
+
+function getLocationPageUrl(slug: string) {
+  return `${WEBSITE_URL}${getLocationPath(slug)}`
+}
+
+function getPostalAddress(location: LocationPageData) {
+  return {
+    '@type': 'PostalAddress',
+    streetAddress: location.streetAddress,
+    addressLocality: location.city,
+    addressRegion: location.state,
+    addressCountry: 'BR',
+    ...(location.postalCode ? { postalCode: location.postalCode } : {}),
+  }
+}
+
+function getServiceSchema(service: LocationService) {
+  return {
+    '@type': 'Service',
+    name: service.name,
+    description: service.description,
+    provider: {
+      '@id': `${WEBSITE_URL}/#physician`,
+    },
+    areaServed: {
+      '@type': 'City',
+      name: 'Curitiba',
+    },
+  }
+}
+
+function getLocationSchema(location: LocationPageData) {
+  return {
+    '@type': 'MedicalClinic',
+    '@id': getLocationSchemaId(location.slug),
+    name: location.name,
+    description: location.schemaDescription,
+    url: getLocationPageUrl(location.slug),
+    telephone: location.phoneDisplay,
+    address: getPostalAddress(location),
+    hasMap: location.mapUrl,
+    availableService: location.schemaServices.map(getServiceSchema),
+    ...(location.clinicWebsite ? { sameAs: [location.clinicWebsite] } : {}),
+  }
+}
+
+export function getHomeLocationsStructuredData() {
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'Physician',
+        '@id': `${WEBSITE_URL}/#physician`,
+        name: DR_NAME,
+        url: WEBSITE_URL,
+        medicalSpecialty: ['Coloproctologia', 'Proctologia'],
+        workLocation: locationPages.map((location) => ({
+          '@id': getLocationSchemaId(location.slug),
+        })),
+      },
+      ...locationPages.map(getLocationSchema),
+    ],
+  })
+}
+
+export function getLocationsIndexStructuredData() {
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'CollectionPage',
+        '@id': `${WEBSITE_URL}${LOCATIONS_BASE_PATH}#webpage`,
+        url: `${WEBSITE_URL}${LOCATIONS_BASE_PATH}`,
+        name: 'Locais de atendimento da Dra. Ana Luiza Rocha',
+        description:
+          'Página que reúne os locais de atendimento e exame relacionados à Dra. Ana Luiza Rocha em Curitiba.',
+        about: [
+          {
+            '@id': `${WEBSITE_URL}/#physician`,
+          },
+        ],
+      },
+      {
+        '@type': 'ItemList',
+        itemListElement: locationPages.map((location, index) => ({
+          '@type': 'ListItem',
+          position: index + 1,
+          url: getLocationPageUrl(location.slug),
+          name: location.name,
+        })),
+      },
+      {
+        '@type': 'Physician',
+        '@id': `${WEBSITE_URL}/#physician`,
+        name: DR_NAME,
+        url: WEBSITE_URL,
+        workLocation: locationPages.map((location) => ({
+          '@id': getLocationSchemaId(location.slug),
+        })),
+      },
+      ...locationPages.map(getLocationSchema),
+      generateBreadcrumbSchema([
+        { label: 'Início', href: '/' },
+        { label: 'Locais de atendimento' },
+      ]),
+    ],
+  })
+}
+
+export function getLocationPageStructuredData(location: LocationPageData) {
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'WebPage',
+        '@id': `${getLocationPageUrl(location.slug)}#webpage`,
+        url: getLocationPageUrl(location.slug),
+        name: location.metaTitle,
+        description: location.metaDescription,
+        about: [
+          {
+            '@id': `${WEBSITE_URL}/#physician`,
+          },
+          {
+            '@id': getLocationSchemaId(location.slug),
+          },
+        ],
+      },
+      {
+        '@type': 'Physician',
+        '@id': `${WEBSITE_URL}/#physician`,
+        name: DR_NAME,
+        url: WEBSITE_URL,
+        medicalSpecialty: ['Coloproctologia', 'Proctologia'],
+        workLocation: [
+          {
+            '@id': getLocationSchemaId(location.slug),
+          },
+        ],
+      },
+      getLocationSchema(location),
+      generateBreadcrumbSchema([
+        { label: 'Início', href: '/' },
+        { label: 'Locais de atendimento', href: LOCATIONS_BASE_PATH },
+        { label: location.name },
+      ]),
+    ],
+  })
+}

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -44,6 +44,12 @@ export const globalNavigation: NavigationItem[] = [
   { name: 'Início', href: '/', id: 'home', type: 'route' },
   { name: 'Blog', href: '/blog', id: 'blog', type: 'route' },
   {
+    name: 'Locais',
+    href: '/locais-de-atendimento',
+    id: 'locais',
+    type: 'route',
+  },
+  {
     name: 'Tratamentos',
     href: '/tratamentos',
     id: 'tratamentos',

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -1,26 +1,23 @@
 import {
   DR_NAME,
-  CLINICA_NASSIF,
-  WPP_NUMBER_NASSIF_FORMATTED,
-  WEBSITE_URL,
-  URL_INSTAGRAM,
   ORG_DESCRIPTION,
   PHYSICIAN_DESCRIPTION,
-  SERVICES_DESCRIPTION,
+  WEBSITE_URL,
+  URL_INSTAGRAM,
   WEBSITE_DESCRIPTION,
-  BUSINESS_DESCRIPTION,
   CRM_NUMBER,
   RQE_NUMBER,
   PUC_PR,
   HOSPITAL_SANTA_CASA,
   HOSPITAL_MACKENZIE,
   HOSPITAL_CLINIC_BARCELONA,
+  WPP_NUMBER_NASSIF_FORMATTED,
 } from './constants'
+import { locationPages, getLocationPath } from './locations'
 
-export const structuredData = {
+const structuredData = {
   '@context': 'https://schema.org',
   '@graph': [
-    // Medical Organization
     {
       '@type': 'MedicalOrganization',
       '@id': `${WEBSITE_URL}/#organization`,
@@ -28,45 +25,17 @@ export const structuredData = {
       url: WEBSITE_URL,
       logo: `${WEBSITE_URL}/images/og.png`,
       description: ORG_DESCRIPTION,
-      address: {
-        '@type': 'PostalAddress',
-        streetAddress: CLINICA_NASSIF.address,
-        addressLocality: CLINICA_NASSIF.city,
-        addressRegion: CLINICA_NASSIF.state,
-        addressCountry: 'BR',
-        postalCode: CLINICA_NASSIF.cep,
-      },
-      geo: {
-        '@type': 'GeoCoordinates',
-        latitude: CLINICA_NASSIF.coordinates.latitude,
-        longitude: CLINICA_NASSIF.coordinates.longitude,
-      },
       telephone: WPP_NUMBER_NASSIF_FORMATTED,
-      priceRange: '$$',
-      openingHours: CLINICA_NASSIF.openingHours,
       areaServed: {
         '@type': 'City',
         name: 'Curitiba',
         addressRegion: 'Paraná',
         addressCountry: 'Brasil',
       },
-      // Reference to the clinic where she works
-      containedInPlace: {
-        '@type': 'MedicalClinic',
-        name: CLINICA_NASSIF.name,
-        url: CLINICA_NASSIF.website,
-        telephone: CLINICA_NASSIF.phoneFormatted,
-        address: {
-          '@type': 'PostalAddress',
-          streetAddress: CLINICA_NASSIF.address,
-          addressLocality: CLINICA_NASSIF.city,
-          addressRegion: CLINICA_NASSIF.state,
-          addressCountry: 'BR',
-          postalCode: CLINICA_NASSIF.cep,
-        },
-      },
+      location: locationPages.map((location) => ({
+        '@id': `${WEBSITE_URL}${getLocationPath(location.slug)}#place`,
+      })),
     },
-    // Medical Professional
     {
       '@type': 'Physician',
       '@id': `${WEBSITE_URL}/#physician`,
@@ -98,12 +67,6 @@ export const structuredData = {
           description: 'Fellow em Cirurgia Colorretal',
         },
       ],
-      memberOf: [
-        {
-          '@type': 'Organization',
-          name: 'International Anal Neoplasia Society (IANS)',
-        },
-      ],
       hasCredential: [
         {
           '@type': 'EducationalOccupationalCredential',
@@ -129,58 +92,14 @@ export const structuredData = {
           },
         },
       ],
-      // Brazilian payment methods and currency
-      paymentAccepted: ['Dinheiro', 'Cartão de Crédito', 'Cartão de Débito', 'PIX'],
-      currenciesAccepted: 'BRL',
       worksFor: {
         '@id': `${WEBSITE_URL}/#organization`,
       },
-      workLocation: {
-        '@type': 'MedicalClinic',
-        name: CLINICA_NASSIF.name,
-        address: {
-          '@type': 'PostalAddress',
-          streetAddress: CLINICA_NASSIF.address,
-          addressLocality: CLINICA_NASSIF.city,
-          addressRegion: CLINICA_NASSIF.state,
-          addressCountry: 'BR',
-          postalCode: CLINICA_NASSIF.cep,
-        },
-        geo: {
-          '@type': 'GeoCoordinates',
-          latitude: CLINICA_NASSIF.coordinates.latitude,
-          longitude: CLINICA_NASSIF.coordinates.longitude,
-        },
-      },
-      medicalSpecialty: [
-        'Coloproctologia',
-        'Cirurgia Colorretal',
-        'Proctologia',
-        'Gastroenterologia Cirúrgica',
-      ],
+      workLocation: locationPages.map((location) => ({
+        '@id': `${WEBSITE_URL}${getLocationPath(location.slug)}#place`,
+      })),
+      medicalSpecialty: ['Coloproctologia', 'Cirurgia Colorretal', 'Proctologia'],
     },
-    // Medical Services
-    {
-      '@type': 'MedicalProcedure',
-      '@id': `${WEBSITE_URL}/#services`,
-      name: 'Serviços de Coloproctologia',
-      description: SERVICES_DESCRIPTION,
-      procedureType: [
-        'Cirurgias a laser',
-        'Botox para fissura anal',
-        'Cirurgias para fístulas anorretais',
-        'Ligadura elástica para hemorroidas',
-        'Tratamento de HPV',
-        'Cirurgia de cisto pilonidal',
-        'Acompanhamento de doenças inflamatórias intestinais',
-        'Tratamento da síndrome do intestino irritável',
-        'Rastreio e prevenção do câncer de canal anal',
-      ],
-      performer: {
-        '@id': `${WEBSITE_URL}/#physician`,
-      },
-    },
-    // Website
     {
       '@type': 'WebSite',
       '@id': `${WEBSITE_URL}/#website`,
@@ -191,32 +110,6 @@ export const structuredData = {
         '@id': `${WEBSITE_URL}/#organization`,
       },
       inLanguage: 'pt-BR',
-    },
-    // Local Business
-    {
-      '@type': 'LocalBusiness',
-      '@id': `${WEBSITE_URL}/#localbusiness`,
-      name: `${DR_NAME} - Coloproctologia`,
-      description: BUSINESS_DESCRIPTION,
-      address: {
-        '@type': 'PostalAddress',
-        streetAddress: CLINICA_NASSIF.address,
-        addressLocality: CLINICA_NASSIF.city,
-        addressRegion: CLINICA_NASSIF.state,
-        addressCountry: 'BR',
-        postalCode: CLINICA_NASSIF.cep,
-      },
-      geo: {
-        '@type': 'GeoCoordinates',
-        latitude: CLINICA_NASSIF.coordinates.latitude,
-        longitude: CLINICA_NASSIF.coordinates.longitude,
-      },
-      telephone: WPP_NUMBER_NASSIF_FORMATTED,
-      url: WEBSITE_URL,
-      image: `${WEBSITE_URL}/images/og.png`,
-      priceRange: '$$',
-      openingHours: CLINICA_NASSIF.openingHours,
-      hasMap: `https://maps.google.com/?q=${CLINICA_NASSIF.coordinates.latitude},${CLINICA_NASSIF.coordinates.longitude}`,
     },
   ],
 }


### PR DESCRIPTION
## What changed

- added a dedicated locations hub and individual location pages for Clínica Nassif and Specta
- centralized location content and physician-to-location structured data in a shared locations module
- updated sitewide and homepage JSON-LD to better represent where Dra. Ana Luiza attends patients
- added sitemap coverage and internal links for the new location pages
- documented the SEO audit and implementation notes in docs/location-seo-spec-report.md

## Why

The site needed stronger semantic SEO signals connecting Dra. Ana Luiza Rocha to her service locations without treating clinic pages as doorway content.

## Impact

- Google and users now have crawlable location-specific pages and clearer structured data
- the homepage keeps its existing card layout while linking into the richer location architecture
- the new pages can now be reviewed and used to capture follow-up issues for design and copy refinement

## Validation

- npm run build
