### PR TITLE
fix(config): add canonical host redirects for apex and http

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -23,18 +23,30 @@ const nextConfig: NextConfig = {
   compiler: {
     removeConsole: process.env.NODE_ENV === 'production' ? { exclude: ['error', 'warn'] } : false,
   },
-  // Permanent redirects for renamed/old URLs
+  // Permanent redirects for renamed/old URLs and canonical host enforcement
   redirects: async () => [
-    // Old treatment slug — page lives at /tratamentos/hpv-anal
+    // Specific slug redirects — old URLs that 404'd
     {
       source: '/tratamentos/tratamento-hpv-anal',
       destination: '/tratamentos/hpv-anal',
       permanent: true,
     },
-    // Old short blog slug — file is cisto-pilonidal-cirurgia-laser-quando-operar
     {
       source: '/blog/cisto-pilonidal-cirurgia-laser',
       destination: '/blog/cisto-pilonidal-cirurgia-laser-quando-operar',
+      permanent: true,
+    },
+    // Canonical host enforcement — belt-and-suspenders alongside Vercel platform config
+    {
+      source: '/:path*',
+      has: [{ type: 'host', value: 'analuizarocha.com.br' }],
+      destination: 'https://www.analuizarocha.com.br/:path*',
+      permanent: true,
+    },
+    {
+      source: '/:path*',
+      has: [{ type: 'header', key: 'x-forwarded-proto', value: 'http' }],
+      destination: 'https://www.analuizarocha.com.br/:path*',
       permanent: true,
     },
   ],


### PR DESCRIPTION
## What changed

Added two redirect rules to `next.config.ts` to enforce `www.analuizarocha.com.br` as the canonical host:

1. **apex → www**: `analuizarocha.com.br/:path*` → `https://www.analuizarocha.com.br/:path*`
2. **http → https**: any request arriving over plain HTTP → HTTPS (belt-and-suspenders alongside Vercel platform config)

Also cleaned up stale inline comments on the existing slug redirects (no functional change).

## Why

Without these redirects, Google may index both `analuizarocha.com.br` and `www.analuizarocha.com.br` as separate entities, splitting link equity. These rules consolidate all traffic to the canonical www+HTTPS variant.

## Risk

Low. The two existing slug redirects are untouched. This is a pure addition.

## Validation

- `bun run build` passes (no API surface change)
- No other files affected

---

> Part of the split from analuizamrocha/web#40