### PR TITLE
feat(locations): add location pages for Clínica Nassif and Specta

### DIFF
--- a/docs/location-seo-spec-report.md
+++ b/docs/location-seo-spec-report.md
@@ -1,0 +1,122 @@
+# Location SEO Spec Report
+
+## Audit findings
+
+- `src/app/layout.tsx` already handled global metadata, canonical, Open Graph, Twitter cards, and local geo hints.
+- JSON-LD already existed in the project via `src/lib/structured-data.ts`, `src/app/page.tsx`, `src/app/sobre/page.tsx`, and treatment pages.
+- The previous structured data strongly favored `Clínica Nassif` and did not model `Specta Endoscopia Digestiva` as a real location entity in the SEO graph.
+- The homepage `LocationsSection` was server-rendered, so its content was crawlable in initial HTML, but the content itself was thin.
+- There was no `/locais-de-atendimento` route, no dedicated location content model, and no reusable location schema helper.
+- Internal linking between locations, treatments, footer, and about content was limited.
+- In code, public location data was only structured for `Clínica Nassif`; `Specta` existed only as a hardcoded homepage card.
+
+## Decision
+
+Chosen approach: `homepage enhancement + dedicated location pages`.
+
+Reasoning:
+
+- There are only two locations, which keeps the architecture simple.
+- Each location supports a distinct user intent:
+  - `Clínica Nassif`: consultation, follow-up, treatment planning.
+  - `Specta Endoscopia Digestiva`: colonoscopy when indicated.
+- This supports useful standalone pages without creating doorway-style duplicates.
+
+## What was implemented
+
+### Shared location model
+
+- Added `src/lib/locations.ts` as the central source for:
+  - location facts
+  - page copy
+  - CTAs
+  - related links
+  - FAQ content
+  - JSON-LD generation
+
+### Structured data
+
+- Updated `src/lib/structured-data.ts` to model the sitewide relationship as:
+  - `MedicalOrganization`
+  - `Physician`
+  - `WebSite`
+- Added homepage location graph via `getHomeLocationsStructuredData()`.
+- Added dedicated location page JSON-LD with:
+  - `WebPage`
+  - `Physician`
+  - `MedicalClinic`
+  - `PostalAddress`
+  - `Service`
+  - `BreadcrumbList`
+
+### New location routes
+
+- Added `/locais-de-atendimento`
+- Added:
+  - `/locais-de-atendimento/clinica-nassif`
+  - `/locais-de-atendimento/specta-endoscopia-digestiva`
+- Added unique metadata, canonical, OG, and Twitter metadata for these pages.
+
+### Internal linking
+
+- Homepage locations section now links to detailed location pages while preserving the original card style.
+- Added location links to:
+  - footer
+  - global navigation
+  - homepage about section
+  - `/sobre`
+  - `/tratamentos`
+
+### Sitemap
+
+- Added the new location routes to `src/app/sitemap.ts`.
+
+## Schema choice reasoning
+
+- I did **not** model the clinics as if the doctor owned them.
+- I preferred `MedicalClinic` for the individual places and kept the doctor's practice relationship centered on `Physician` + `MedicalOrganization`.
+- I used `Service` on location pages instead of more specific medical subtypes when the site copy did not justify a narrower claim.
+- I avoided review schema, unsupported ownership claims, and any facts not visible on the site.
+
+## Files changed
+
+- `src/app/layout.tsx`
+- `src/app/page.tsx`
+- `src/app/sitemap.ts`
+- `src/app/sobre/page.tsx`
+- `src/app/tratamentos/page.tsx`
+- `src/app/locais-de-atendimento/page.tsx`
+- `src/app/locais-de-atendimento/[slug]/page.tsx`
+- `src/components/sections/AboutSection.tsx`
+- `src/components/sections/LocationsSection.tsx`
+- `src/components/ui/Footer.tsx`
+- `src/lib/constants.ts`
+- `src/lib/faq-schema.ts`
+- `src/lib/navigation.ts`
+- `src/lib/locations.ts`
+- `src/lib/structured-data.ts`
+
+## Risks and limitations
+
+- `Specta Endoscopia Digestiva` still has less factual detail available in code than `Clínica Nassif`.
+- The site still has no dedicated contact page; contact intent is handled through WhatsApp and phone CTAs.
+- If the clinic facts used on the site differ from Google Business Profile or clinic-managed listings, the entity association can remain weaker than desired.
+- If future service-location relationships change, `src/lib/locations.ts` must be updated to keep visible content and schema aligned.
+
+## Validation performed
+
+- Ran `npm run build` successfully after implementation.
+- Confirmed the new routes were statically generated:
+  - `/locais-de-atendimento`
+  - `/locais-de-atendimento/clinica-nassif`
+  - `/locais-de-atendimento/specta-endoscopia-digestiva`
+
+## Next manual SEO steps
+
+1. Inspect the homepage in Google Search Console.
+2. Inspect each location page in Google Search Console.
+3. Test the homepage and both location pages in Rich Results Test.
+4. Confirm clinic names and addresses are present in visible HTML exactly as intended.
+5. Request indexing for the updated homepage and each new location page.
+6. Verify consistency between website location details and Google Business Profile / clinic listings.
+7. If the clinics can provide more verified public details, expand the location pages with those facts instead of generic explanatory copy.

--- a/src/app/locais-de-atendimento/[slug]/page.tsx
+++ b/src/app/locais-de-atendimento/[slug]/page.tsx
@@ -1,0 +1,248 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { ArrowRight, Phone } from 'lucide-react'
+import { Breadcrumb } from '@/components/ui/Breadcrumb'
+import { LinkButton } from '@/components/ui/LinkButton'
+import { Badge } from '@/components/ui/Badge'
+import { CallToActionCard } from '@/components/ui/CallToActionCard'
+import { generateOpenGraphMetadata, generateTwitterMetadata } from '@/lib/seo-schemas'
+import {
+  getLocationBySlug,
+  getLocationPageStructuredData,
+  getLocationPath,
+  locationPages,
+} from '@/lib/locations'
+import { WEBSITE_URL } from '@/lib/constants'
+
+interface LocationPageProps {
+  params: Promise<{
+    slug: string
+  }>
+}
+
+export async function generateStaticParams() {
+  return locationPages.map((location) => ({
+    slug: location.slug,
+  }))
+}
+
+export async function generateMetadata({ params }: LocationPageProps): Promise<Metadata> {
+  const { slug } = await params
+  const location = getLocationBySlug(slug)
+
+  if (!location) {
+    return {
+      title: 'Local não encontrado',
+    }
+  }
+
+  const pageUrl = `${WEBSITE_URL}${getLocationPath(location.slug)}`
+
+  return {
+    title: location.metaTitle,
+    description: location.metaDescription,
+    alternates: {
+      canonical: pageUrl,
+    },
+    openGraph: generateOpenGraphMetadata({
+      title: location.metaTitle,
+      description: location.metaDescription,
+      url: pageUrl,
+    }),
+    twitter: generateTwitterMetadata({
+      title: location.metaTitle,
+      description: location.metaDescription,
+      url: pageUrl,
+    }),
+  }
+}
+
+export default async function LocationPage({ params }: LocationPageProps) {
+  const { slug } = await params
+  const location = getLocationBySlug(slug)
+
+  if (!location) {
+    notFound()
+  }
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: getLocationPageStructuredData(location),
+        }}
+      />
+
+      <section className="section bg-background pt-24 md:pt-28 animate-fade-in">
+        <div className="max-w-[1760px] mx-auto px-6 sm:px-8 lg:px-10 xl:px-12">
+          <Breadcrumb
+            items={[
+              { label: 'Início', href: '/' },
+              { label: 'Locais de atendimento', href: '/locais-de-atendimento' },
+              { label: location.name },
+            ]}
+          />
+
+          <div className="mx-auto max-w-4xl">
+            <header className="mb-10 lg:mb-12 text-center">
+              <div className="flex flex-wrap items-center justify-center gap-2 mb-5">
+                <Badge variant="secondary" size="lg">
+                  {location.badgeLabel}
+                </Badge>
+              </div>
+
+              <h1 className="text-3xl sm:text-4xl lg:text-5xl font-serif font-bold text-primary mb-6 leading-tight">
+                {location.pageTitle}
+              </h1>
+
+              <p className="text-lg md:text-xl lg:text-2xl text-secondary leading-relaxed font-medium max-w-3xl mx-auto">
+                {location.visibleRelationshipText}
+              </p>
+            </header>
+
+            <div className="rounded-3xl border border-secondary/20 bg-secondary/10 p-8 lg:p-10 mb-10">
+              <h2 className="text-2xl lg:text-3xl font-serif font-bold text-primary mb-4">
+                Endereço e contato
+              </h2>
+
+              <address className="not-italic text-lg text-secondary leading-relaxed mb-5">
+                {location.addressLines[0]}
+                <br />
+                {location.addressLines[1]}
+              </address>
+
+              <div className="flex flex-col sm:flex-row sm:items-center gap-4 text-base lg:text-lg">
+                <a
+                  href={location.phoneHref}
+                  className="inline-flex items-center gap-3 text-secondary hover:text-primary transition-colors"
+                >
+                  <Phone className="size-5 text-primary" aria-hidden="true" />
+                  <span>{location.phoneDisplay}</span>
+                </a>
+
+                <a
+                  href={location.mapUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 text-primary hover:text-primary/80 transition-colors font-medium"
+                >
+                  Ver mapa e rota
+                  <ArrowRight className="size-4" aria-hidden="true" />
+                </a>
+              </div>
+            </div>
+
+            <main className="prose prose-lg max-w-none mb-10 lg:mb-12">
+              <h2 className="text-3xl font-serif font-bold text-primary mb-6 text-center">
+                Como este local se encaixa no cuidado
+              </h2>
+
+              {location.overviewParagraphs.map((paragraph) => (
+                <p key={paragraph} className="text-lg text-secondary leading-relaxed mb-4">
+                  {paragraph}
+                </p>
+              ))}
+
+              <h2 className="text-3xl font-serif font-bold text-primary mb-6 text-center">
+                {location.servicesTitle}
+              </h2>
+              <ul>
+                {location.services.map((service) => (
+                  <li key={service}>{service}</li>
+                ))}
+              </ul>
+
+              <h2 className="text-3xl font-serif font-bold text-primary mb-6 text-center">
+                Informações práticas
+              </h2>
+              <ul>
+                {location.practicalInfo.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </main>
+
+            <CallToActionCard
+              title="Agendamento"
+              body={<p>{location.schedulingDescription}</p>}
+              actions={
+                <>
+                  <LinkButton href={location.whatsappHref} external newTab variant="primary">
+                    {location.primaryCtaLabel}
+                  </LinkButton>
+                  <LinkButton href="/locais-de-atendimento" variant="outline">
+                    Ver todos os locais
+                  </LinkButton>
+                </>
+              }
+              variant="secondary"
+            />
+
+            <div className="rounded-3xl border border-secondary/20 bg-secondary/10 p-8 lg:p-10 mb-10">
+              <h2 className="text-2xl lg:text-3xl font-serif font-bold text-primary mb-5">
+                Tratamentos relacionados
+              </h2>
+              <div className="space-y-3">
+                {location.relatedTreatments.map((link) => (
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    className="flex items-start justify-between gap-3 rounded-2xl border border-secondary/15 bg-background px-4 py-4 text-secondary hover:border-primary/30 hover:text-primary transition-colors"
+                  >
+                    <span>{link.label}</span>
+                    <ArrowRight className="size-4 flex-shrink-0 mt-1" aria-hidden="true" />
+                  </Link>
+                ))}
+              </div>
+            </div>
+
+            {location.relatedArticles && location.relatedArticles.length > 0 && (
+              <div className="rounded-3xl border border-secondary/20 bg-secondary/10 p-8 lg:p-10 mb-10">
+                <h2 className="text-2xl lg:text-3xl font-serif font-bold text-primary mb-5">
+                  Leituras úteis
+                </h2>
+                <div className="space-y-3">
+                  {location.relatedArticles.map((link) => (
+                    <Link
+                      key={link.href}
+                      href={link.href}
+                      className="flex items-start justify-between gap-3 rounded-2xl border border-secondary/15 bg-background px-4 py-4 text-secondary hover:border-primary/30 hover:text-primary transition-colors"
+                    >
+                      <span>{link.label}</span>
+                      <ArrowRight className="size-4 flex-shrink-0 mt-1" aria-hidden="true" />
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div className="rounded-3xl border border-secondary/20 bg-background p-8 lg:p-10 mb-8">
+              <h2 className="text-2xl lg:text-3xl font-serif font-bold text-primary mb-6">
+                Perguntas frequentes
+              </h2>
+              <div className="space-y-6">
+                {location.faq.map((item) => (
+                  <div key={item.question}>
+                    <h3 className="text-xl font-semibold text-primary mb-2">{item.question}</h3>
+                    <p className="text-lg text-secondary leading-relaxed">{item.answer}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="text-center">
+              <Link
+                href="/"
+                className="inline-flex items-center text-primary hover:text-primary/80 font-medium transition-colors text-lg"
+              >
+                ← Voltar ao início
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+    </>
+  )
+}

--- a/src/app/locais-de-atendimento/[slug]/page.tsx
+++ b/src/app/locais-de-atendimento/[slug]/page.tsx
@@ -9,6 +9,7 @@ import { CallToActionCard } from '@/components/ui/CallToActionCard'
 import { generateOpenGraphMetadata, generateTwitterMetadata } from '@/lib/seo-schemas'
 import {
   getLocationBySlug,
+  getLocationFAQStructuredData,
   getLocationPageStructuredData,
   getLocationPath,
   locationPages,
@@ -40,7 +41,9 @@ export async function generateMetadata({ params }: LocationPageProps): Promise<M
   const pageUrl = `${WEBSITE_URL}${getLocationPath(location.slug)}`
 
   return {
-    title: location.metaTitle,
+    title: {
+      absolute: location.metaTitle,
+    },
     description: location.metaDescription,
     alternates: {
       canonical: pageUrl,
@@ -72,6 +75,12 @@ export default async function LocationPage({ params }: LocationPageProps) {
         type="application/ld+json"
         dangerouslySetInnerHTML={{
           __html: getLocationPageStructuredData(location),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: getLocationFAQStructuredData(location),
         }}
       />
 

--- a/src/app/locais-de-atendimento/page.tsx
+++ b/src/app/locais-de-atendimento/page.tsx
@@ -1,0 +1,191 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowRight, MapPin } from 'lucide-react'
+import { Breadcrumb } from '@/components/ui/Breadcrumb'
+import { LinkButton } from '@/components/ui/LinkButton'
+import { Badge } from '@/components/ui/Badge'
+import { CallToActionCard } from '@/components/ui/CallToActionCard'
+import { generateOpenGraphMetadata, generateTwitterMetadata } from '@/lib/seo-schemas'
+import {
+  LOCATIONS_BASE_PATH,
+  getLocationPath,
+  getLocationsIndexStructuredData,
+  locationPages,
+} from '@/lib/locations'
+import { WEBSITE_URL } from '@/lib/constants'
+
+const pageTitle = 'Locais de atendimento em Curitiba'
+const pageDescription =
+  'Veja onde a Dra. Ana Luiza Rocha atende em Curitiba, com informações sobre consulta em coloproctologia, colonoscopia, endereços e agendamento.'
+const pageUrl = `${WEBSITE_URL}${LOCATIONS_BASE_PATH}`
+
+export const metadata: Metadata = {
+  title: pageTitle,
+  description: pageDescription,
+  alternates: {
+    canonical: pageUrl,
+  },
+  openGraph: generateOpenGraphMetadata({
+    title: pageTitle,
+    description: pageDescription,
+    url: pageUrl,
+  }),
+  twitter: generateTwitterMetadata({
+    title: pageTitle,
+    description: pageDescription,
+    url: pageUrl,
+  }),
+}
+
+export default function LocationsIndexPage() {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: getLocationsIndexStructuredData(),
+        }}
+      />
+
+      <section className="section bg-background pt-24 md:pt-28 animate-fade-in">
+        <div className="max-w-[1760px] mx-auto px-6 sm:px-8 lg:px-10 xl:px-12">
+          <Breadcrumb items={[{ label: 'Início', href: '/' }, { label: 'Locais de atendimento' }]} />
+
+          <div className="mx-auto max-w-4xl text-center mb-12 lg:mb-16">
+            <div className="flex flex-wrap items-center justify-center gap-2 mb-5">
+              <Badge variant="secondary" size="lg">
+                Consulta em coloproctologia
+              </Badge>
+              <Badge variant="secondary" size="lg">
+                Colonoscopia quando indicada
+              </Badge>
+            </div>
+
+            <h1 className="text-3xl sm:text-5xl lg:text-6xl font-serif font-bold text-primary mb-6">
+              Locais de atendimento da Dra. Ana Luiza Rocha
+            </h1>
+
+            <div className="text-lg md:text-xl lg:text-2xl leading-relaxed text-secondary font-medium space-y-4">
+              <p>
+                Aqui você encontra os locais relacionados ao atendimento da Dra. Ana Luiza em
+                Curitiba.
+              </p>
+              <p>
+                Um deles concentra as consultas e o acompanhamento em coloproctologia. O outro é
+                usado quando a colonoscopia faz parte da investigação ou do rastreio indicado.
+              </p>
+            </div>
+          </div>
+
+          <div className="mx-auto max-w-5xl grid grid-cols-1 gap-6 lg:gap-8 mb-12 lg:mb-16">
+            {locationPages.map((location) => (
+              <article
+                key={location.slug}
+                className="rounded-3xl border border-secondary/20 bg-secondary/10 p-7 lg:p-8 shadow-sm"
+              >
+                <div className="flex items-start gap-4 mb-5">
+                  <div className="rounded-full bg-primary/10 p-3 flex-shrink-0">
+                    <MapPin className="size-5 text-primary" aria-hidden="true" />
+                  </div>
+
+                  <div className="min-w-0 flex-1">
+                    <Badge variant="secondary" className="mb-3">
+                      {location.badgeLabel}
+                    </Badge>
+                    <h2 className="text-2xl lg:text-3xl font-serif font-bold text-primary mb-3">
+                      {location.name}
+                    </h2>
+                    <p className="text-lg text-secondary leading-relaxed mb-4">
+                      {location.visibleRelationshipText}
+                    </p>
+                    <address className="not-italic text-base lg:text-lg text-secondary leading-relaxed">
+                      {location.addressLines[0]}
+                      <br />
+                      {location.addressLines[1]}
+                    </address>
+                  </div>
+                </div>
+
+                <p className="text-base lg:text-lg text-secondary leading-relaxed mb-5">
+                  {location.cardDescription}
+                </p>
+
+                <ul className="space-y-3 text-base lg:text-lg text-secondary mb-6">
+                  {location.services.slice(0, 2).map((service) => (
+                    <li key={service} className="flex gap-3">
+                      <span className="mt-2 size-2 rounded-full bg-primary/50 flex-shrink-0" />
+                      <span>{service}</span>
+                    </li>
+                  ))}
+                </ul>
+
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 pt-5 border-t border-secondary/10">
+                  <div className="flex flex-wrap gap-4 text-sm lg:text-base font-medium">
+                    <a
+                      href={location.mapUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-primary hover:text-primary/80 transition-colors"
+                    >
+                      Ver mapa
+                    </a>
+                    <Link
+                      href={getLocationPath(location.slug)}
+                      className="inline-flex items-center gap-2 text-primary hover:text-primary/80 transition-colors"
+                    >
+                      Ver detalhes
+                      <ArrowRight className="size-4" aria-hidden="true" />
+                    </Link>
+                  </div>
+
+                  <LinkButton
+                    href={location.whatsappHref}
+                    external
+                    newTab
+                    variant="primary"
+                    className="w-full sm:w-auto text-sm font-semibold px-5"
+                  >
+                    {location.primaryCtaLabel}
+                  </LinkButton>
+                </div>
+              </article>
+            ))}
+          </div>
+
+          <div className="mx-auto max-w-5xl">
+            <CallToActionCard
+              title="Ainda em dúvida sobre qual local faz mais sentido?"
+              body={
+                <p>
+                  Se a sua necessidade é consulta, retorno ou definição de conduta, comece pela
+                  avaliação em coloproctologia. Se houver indicação de colonoscopia, a orientação
+                  pode seguir para o local apropriado.
+                </p>
+              }
+              actions={
+                <>
+                  <LinkButton href="/tratamentos" variant="outline">
+                    Ver tratamentos
+                  </LinkButton>
+                  <LinkButton href="/sobre" variant="subtle">
+                    Conhecer a trajetória da Dra. Ana
+                  </LinkButton>
+                </>
+              }
+              variant="secondary"
+            />
+          </div>
+
+          <div className="mt-2 text-center">
+            <Link
+              href="/"
+              className="inline-flex items-center text-primary hover:text-primary/80 font-medium transition-colors text-lg"
+            >
+              ← Voltar ao início
+            </Link>
+          </div>
+        </div>
+      </section>
+    </>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,10 +8,17 @@ import {
   AboutSection,
 } from '@/components/sections'
 import { getFAQSchema } from '@/lib/faq-schema'
+import { getHomeLocationsStructuredData } from '@/lib/locations'
 
 export default function Home() {
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: getHomeLocationsStructuredData(),
+        }}
+      />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -5,6 +5,9 @@ import { WEBSITE_URL } from '@/lib/constants'
 const STATIC_ROUTE_LAST_MODIFIED: Record<string, string> = {
   '/': '2026-04-01',
   '/blog': '2026-04-01',
+  '/locais-de-atendimento': '2026-04-11',
+  '/locais-de-atendimento/clinica-nassif': '2026-04-11',
+  '/locais-de-atendimento/specta-endoscopia-digestiva': '2026-04-11',
   '/sobre': '2026-03-20',
   '/tratamentos': '2026-03-20',
   '/tratamentos/hemorroidas': '2026-03-20',
@@ -67,6 +70,24 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: STATIC_ROUTE_LAST_MODIFIED['/tratamentos'],
       changeFrequency: 'monthly' as const,
       priority: 0.95,
+    },
+    {
+      url: `${WEBSITE_URL}/locais-de-atendimento`,
+      lastModified: STATIC_ROUTE_LAST_MODIFIED['/locais-de-atendimento'],
+      changeFrequency: 'monthly' as const,
+      priority: 0.9,
+    },
+    {
+      url: `${WEBSITE_URL}/locais-de-atendimento/clinica-nassif`,
+      lastModified: STATIC_ROUTE_LAST_MODIFIED['/locais-de-atendimento/clinica-nassif'],
+      changeFrequency: 'monthly' as const,
+      priority: 0.8,
+    },
+    {
+      url: `${WEBSITE_URL}/locais-de-atendimento/specta-endoscopia-digestiva`,
+      lastModified: STATIC_ROUTE_LAST_MODIFIED['/locais-de-atendimento/specta-endoscopia-digestiva'],
+      changeFrequency: 'monthly' as const,
+      priority: 0.8,
     },
     // Individual treatment pages - Very high priority
     ...treatmentEntries,

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -9,9 +9,6 @@ import {
   WPP_NUMBER_NASSIF,
   WHATSAPP_MSG_TEXT_ENCODED,
   WEBSITE_URL,
-  CLINICA_NASSIF,
-  DR_NAME,
-  WPP_NUMBER_NASSIF_FORMATTED,
   URL_INSTAGRAM,
   CRM_NUMBER,
   RQE_NUMBER,
@@ -23,7 +20,6 @@ import {
   generateBreadcrumbSchema,
   generateOpenGraphMetadata,
   generateTwitterMetadata,
-  generateLocalBusinessSchema,
   type BreadcrumbItem,
 } from '@/lib/seo-schemas'
 import {
@@ -198,36 +194,6 @@ export default function SobrePage() {
               addressCountry: 'BR',
             },
           }),
-        }}
-      />
-
-      {/* LocalBusiness Schema */}
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify(
-            generateLocalBusinessSchema({
-              name: `${DR_NAME} - Coloproctologia`,
-              description:
-                'Consultas de Coloproctologia com atendimento humanizado e especializado em Curitiba. Diagnóstico e tratamento de doenças do intestino, reto e ânus.',
-              address: {
-                streetAddress: CLINICA_NASSIF.address,
-                addressLocality: CLINICA_NASSIF.city,
-                addressRegion: CLINICA_NASSIF.state,
-                postalCode: CLINICA_NASSIF.cep,
-                addressCountry: 'BR',
-              },
-              geo: {
-                latitude: CLINICA_NASSIF.coordinates.latitude,
-                longitude: CLINICA_NASSIF.coordinates.longitude,
-              },
-              telephone: WPP_NUMBER_NASSIF_FORMATTED,
-              url: WEBSITE_URL,
-              image: `${WEBSITE_URL}/images/og.png`,
-              priceRange: '$$',
-              openingHours: CLINICA_NASSIF.openingHours,
-            })
-          ),
         }}
       />
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -112,6 +112,9 @@ export const CLINICA_NASSIF = {
   /** Clinic name */
   name: 'Clínica Nassif',
 
+  /** Short name for patient-facing copy */
+  shortName: 'Clínica Nassif',
+
   /** Street address */
   address: 'Rua Bruno Filgueira, 489',
 
@@ -168,6 +171,9 @@ export const CLINICA_NASSIF = {
 export const SPECTA_ENDOSCOPIA = {
   /** Clinic name */
   name: 'Specta Endoscopia Digestiva',
+
+  /** Short name for patient-facing copy */
+  shortName: 'Specta',
 
   /** Street address */
   address: 'R. Dom Alberto Gonçalves, 311',

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -160,3 +160,34 @@ export const CLINICA_NASSIF = {
   /** Opening hours formatted for display */
   openingHoursDisplay: 'Segunda a Sexta: 08:00 - 19:30',
 } as const
+
+// =============================================================================
+// Specta Endoscopia Digestiva Information
+// =============================================================================
+
+export const SPECTA_ENDOSCOPIA = {
+  /** Clinic name */
+  name: 'Specta Endoscopia Digestiva',
+
+  /** Street address */
+  address: 'R. Dom Alberto Gonçalves, 311',
+
+  /** Neighborhood */
+  neighborhood: 'Mercês',
+
+  /** City */
+  city: 'Curitiba',
+
+  /** State abbreviation */
+  state: 'PR',
+
+  /** State full name */
+  stateFull: 'Paraná',
+
+  /** Contact phone used on the website */
+  phone: '(41) 98773-7829',
+
+  /** Google Maps search URL */
+  maps:
+    'https://maps.google.com/?q=R.%20Dom%20Alberto%20Gon%C3%A7alves%2C%20311%2C%20Merc%C3%AAs%2C%20Curitiba%20-%20PR',
+} as const

--- a/src/lib/faq-schema.ts
+++ b/src/lib/faq-schema.ts
@@ -1,8 +1,4 @@
-import {
-  CLINICA_NASSIF,
-  SPECTA_ENDOSCOPIA,
-  WPP_NUMBER_NASSIF_FORMATTED,
-} from './constants'
+import { CLINICA_NASSIF, SPECTA_ENDOSCOPIA, WPP_NUMBER_NASSIF_FORMATTED } from './constants'
 
 export const faqSchema = {
   '@context': 'https://schema.org',
@@ -37,7 +33,7 @@ export const faqSchema = {
       name: 'Onde a Dra. Ana Luiza atende em Curitiba?',
       acceptedAnswer: {
         '@type': 'Answer',
-        text: `As consultas em coloproctologia acontecem na ${CLINICA_NASSIF.name}, localizada na ${CLINICA_NASSIF.address}, no bairro ${CLINICA_NASSIF.neighborhood}, em ${CLINICA_NASSIF.city} - ${CLINICA_NASSIF.state}. Quando a colonoscopia é indicada, o site também informa a ${SPECTA_ENDOSCOPIA.name}, na ${SPECTA_ENDOSCOPIA.address}, no bairro ${SPECTA_ENDOSCOPIA.neighborhood}.`,
+        text: `As consultas acontecem na ${CLINICA_NASSIF.name}, localizada na ${CLINICA_NASSIF.address}, no bairro ${CLINICA_NASSIF.neighborhood}, em ${CLINICA_NASSIF.city} - ${CLINICA_NASSIF.state}. A ${SPECTA_ENDOSCOPIA.name}, na ${SPECTA_ENDOSCOPIA.address}, no bairro ${SPECTA_ENDOSCOPIA.neighborhood}, é o local onde a colonoscopia é realizada quando há indicação para o exame.`,
       },
     },
     {
@@ -45,7 +41,7 @@ export const faqSchema = {
       name: 'Como agendar uma consulta?',
       acceptedAnswer: {
         '@type': 'Answer',
-        text: `Você pode agendar uma consulta através do WhatsApp ${WPP_NUMBER_NASSIF_FORMATTED} ou pelo telefone da ${CLINICA_NASSIF.name} ${CLINICA_NASSIF.phone}.`,
+        text: `Você pode agendar uma consulta pelo WhatsApp ou pelo telefone da ${CLINICA_NASSIF.name} ${WPP_NUMBER_NASSIF_FORMATTED}.`,
       },
     },
   ],

--- a/src/lib/faq-schema.ts
+++ b/src/lib/faq-schema.ts
@@ -41,7 +41,7 @@ export const faqSchema = {
       name: 'Como agendar uma consulta?',
       acceptedAnswer: {
         '@type': 'Answer',
-        text: `Você pode agendar uma consulta pelo WhatsApp ou pelo telefone da ${CLINICA_NASSIF.name} ${WPP_NUMBER_NASSIF_FORMATTED}.`,
+        text: `Você pode agendar uma consulta pelo WhatsApp ${WPP_NUMBER_NASSIF_FORMATTED} ou pelo telefone da ${CLINICA_NASSIF.name} ${CLINICA_NASSIF.phone}.`,
       },
     },
   ],

--- a/src/lib/faq-schema.ts
+++ b/src/lib/faq-schema.ts
@@ -1,4 +1,8 @@
-import { WPP_NUMBER_NASSIF_FORMATTED, CLINICA_NASSIF } from './constants'
+import {
+  CLINICA_NASSIF,
+  SPECTA_ENDOSCOPIA,
+  WPP_NUMBER_NASSIF_FORMATTED,
+} from './constants'
 
 export const faqSchema = {
   '@context': 'https://schema.org',
@@ -30,10 +34,10 @@ export const faqSchema = {
     },
     {
       '@type': 'Question',
-      name: 'Onde fica o consultório em Curitiba?',
+      name: 'Onde a Dra. Ana Luiza atende em Curitiba?',
       acceptedAnswer: {
         '@type': 'Answer',
-        text: `O consultório fica na ${CLINICA_NASSIF.name}, localizada na ${CLINICA_NASSIF.address}, no bairro ${CLINICA_NASSIF.neighborhood}, em ${CLINICA_NASSIF.city} - ${CLINICA_NASSIF.state}.`,
+        text: `As consultas em coloproctologia acontecem na ${CLINICA_NASSIF.name}, localizada na ${CLINICA_NASSIF.address}, no bairro ${CLINICA_NASSIF.neighborhood}, em ${CLINICA_NASSIF.city} - ${CLINICA_NASSIF.state}. Quando a colonoscopia é indicada, o site também informa a ${SPECTA_ENDOSCOPIA.name}, na ${SPECTA_ENDOSCOPIA.address}, no bairro ${SPECTA_ENDOSCOPIA.neighborhood}.`,
       },
     },
     {

--- a/src/lib/locations.ts
+++ b/src/lib/locations.ts
@@ -27,6 +27,8 @@ type RelatedLink = {
 type LocationService = {
   name: string
   description: string
+  // schema.org: availableService on MedicalClinic accepts MedicalTherapy | MedicalTest | MedicalProcedure
+  schemaType?: 'MedicalTherapy' | 'MedicalTest' | 'MedicalProcedure'
 }
 
 export interface LocationPageData {
@@ -239,6 +241,7 @@ export const locationPages: LocationPageData[] = [
         name: 'Colonoscopia',
         description:
           'Exame endoscópico realizado com a Dra. Ana Luiza Rocha quando há indicação clínica ou preventiva.',
+        schemaType: 'MedicalTest' as const,
       },
     ],
   },
@@ -273,7 +276,7 @@ function getPostalAddress(location: LocationPageData) {
 
 function getServiceSchema(service: LocationService) {
   return {
-    '@type': 'Service',
+    '@type': service.schemaType ?? 'MedicalTherapy',
     name: service.name,
     description: service.description,
     provider: {

--- a/src/lib/locations.ts
+++ b/src/lib/locations.ts
@@ -1,0 +1,406 @@
+import {
+  CLINICA_NASSIF,
+  DR_NAME,
+  SPECTA_ENDOSCOPIA,
+  WEBSITE_URL,
+  WHATSAPP_MSG_TEXT_ENCODED,
+  WPP_NUMBER_NASSIF,
+} from './constants'
+import { generateBreadcrumbSchema, type FAQItem } from './seo-schemas'
+
+export const LOCATIONS_BASE_PATH = '/locais-de-atendimento'
+
+const WHATSAPP_COLONOSCOPY_TEXT = encodeURIComponent(
+  'Olá! Gostaria de agendar minha colonoscopia com a Dra. Ana Luiza Rocha.'
+)
+
+const createWhatsAppHref = (phone: string, encodedText: string) =>
+  `https://wa.me/${phone.replace(/\D/g, '')}/?text=${encodedText}`
+
+const createPhoneHref = (phone: string) => `tel:${phone.replace(/\D/g, '')}`
+
+type RelatedLink = {
+  href: string
+  label: string
+}
+
+type LocationService = {
+  name: string
+  description: string
+}
+
+export interface LocationPageData {
+  slug: string
+  name: string
+  shortName: string
+  badgeLabel: string
+  pageTitle: string
+  metaTitle: string
+  metaDescription: string
+  summary: string
+  cardDescription: string
+  visibleRelationshipText: string
+  addressLines: [string, string]
+  streetAddress: string
+  neighborhood: string
+  city: string
+  state: string
+  postalCode?: string
+  phoneDisplay: string
+  phoneHref: string
+  whatsappDisplay: string
+  whatsappHref: string
+  mapUrl: string
+  mapLabel: string
+  primaryCtaLabel: string
+  schedulingDescription: string
+  servicesTitle: string
+  services: string[]
+  overviewParagraphs: string[]
+  practicalInfo: string[]
+  relatedTreatments: RelatedLink[]
+  relatedArticles?: RelatedLink[]
+  faq: FAQItem[]
+  schemaDescription: string
+  schemaServices: LocationService[]
+  clinicWebsite?: string
+}
+
+export const locationPages: LocationPageData[] = [
+  {
+    slug: 'clinica-nassif',
+    name: CLINICA_NASSIF.name,
+    shortName: 'Clínica Nassif',
+    badgeLabel: 'Consulta em coloproctologia',
+    pageTitle: 'Clínica Nassif',
+    metaTitle: 'Clínica Nassif | Onde a Dra. Ana Luiza Rocha atende em Curitiba',
+    metaDescription:
+      'Consultas em coloproctologia com a Dra. Ana Luiza Rocha na Clínica Nassif, no Batel, em Curitiba. Veja endereço, como agendar e tratamentos relacionados.',
+    summary: 'Consultas, retornos e acompanhamento no Batel.',
+    cardDescription:
+      'Local indicado para consulta inicial, retorno e definição do plano de cuidado em coloproctologia.',
+    visibleRelationshipText:
+      'A Dra. Ana Luiza Rocha atende na Clínica Nassif para consultas, retornos e acompanhamento em coloproctologia.',
+    addressLines: ['Rua Bruno Filgueira, 489', 'Batel, Curitiba - PR'],
+    streetAddress: CLINICA_NASSIF.address,
+    neighborhood: CLINICA_NASSIF.neighborhood,
+    city: CLINICA_NASSIF.city,
+    state: CLINICA_NASSIF.state,
+    postalCode: CLINICA_NASSIF.cep,
+    phoneDisplay: CLINICA_NASSIF.phone,
+    phoneHref: createPhoneHref(CLINICA_NASSIF.phoneFormatted),
+    whatsappDisplay: CLINICA_NASSIF.wpp,
+    whatsappHref: createWhatsAppHref(WPP_NUMBER_NASSIF, WHATSAPP_MSG_TEXT_ENCODED),
+    mapUrl: CLINICA_NASSIF.maps,
+    mapLabel: 'Ver rota para a Clínica Nassif',
+    primaryCtaLabel: 'Agendar consulta na Clínica Nassif',
+    schedulingDescription:
+      'Este é o principal local para consulta, reavaliação, retorno e organização do cuidado clínico ou cirúrgico com a Dra. Ana Luiza.',
+    servicesTitle: 'Quando este local faz mais sentido',
+    services: [
+      'Consulta inicial para avaliar sintomas, histórico e exames já realizados.',
+      'Retornos e seguimento de tratamentos clínicos, ambulatoriais e cirúrgicos.',
+      'Discussão de condutas para hemorroidas, fissura anal, fístulas, HPV anal e doenças inflamatórias intestinais.',
+      'Orientação sobre exames e encaminhamento para procedimentos quando indicados.',
+    ],
+    overviewParagraphs: [
+      'A Clínica Nassif é a principal referência para consulta com a Dra. Ana Luiza em Curitiba. É aqui que acontece a avaliação inicial, a revisão de exames e o acompanhamento ao longo do tratamento.',
+      'Na consulta, a proposta é entender a queixa com calma, revisar hipóteses diagnósticas e definir o próximo passo do cuidado de forma individualizada.',
+    ],
+    practicalInfo: [
+      'O endereço fica no Batel, bairro de fácil acesso para quem busca atendimento em Curitiba.',
+      'Se você já tiver exames, laudos ou receitas recentes, vale levá-los para a consulta.',
+      'O agendamento pode ser feito pelo WhatsApp da equipe ou pelo telefone da clínica.',
+    ],
+    relatedTreatments: [
+      { href: '/tratamentos/hemorroidas', label: 'Tratamento de hemorroidas' },
+      { href: '/tratamentos/toxina-botulinica', label: 'Toxina botulínica para fissura anal' },
+      { href: '/tratamentos/cx-laser', label: 'Cirurgias a laser em coloproctologia' },
+    ],
+    faq: [
+      {
+        question: 'A primeira consulta com a Dra. Ana Luiza acontece na Clínica Nassif?',
+        answer:
+          'Sim. A Clínica Nassif é um dos locais indicados para consulta inicial, retorno e organização do plano de cuidado em coloproctologia.',
+      },
+      {
+        question: 'Posso agendar retorno neste mesmo local?',
+        answer:
+          'Sim. O acompanhamento clínico e o seguimento após tratamentos podem ser organizados pela equipe da Clínica Nassif.',
+      },
+      {
+        question: 'Quais sintomas costumam motivar consulta neste local?',
+        answer:
+          'Queixas como dor ao evacuar, sangramento, coceira anal, hemorroidas, fissuras, alterações do hábito intestinal e necessidade de acompanhamento especializado costumam ser avaliadas em consulta.',
+      },
+    ],
+    schemaDescription:
+      'Clínica em Curitiba onde a Dra. Ana Luiza Rocha realiza consultas, retornos e acompanhamento em coloproctologia.',
+    schemaServices: [
+      {
+        name: 'Consulta em coloproctologia',
+        description:
+          'Avaliação inicial, revisão de sintomas e definição de conduta com a Dra. Ana Luiza Rocha.',
+      },
+      {
+        name: 'Retorno e acompanhamento',
+        description:
+          'Seguimento clínico e pós-tratamento em doenças do intestino, reto e ânus.',
+      },
+    ],
+    clinicWebsite: CLINICA_NASSIF.website,
+  },
+  {
+    slug: 'specta-endoscopia-digestiva',
+    name: SPECTA_ENDOSCOPIA.name,
+    shortName: 'Specta Endoscopia Digestiva',
+    badgeLabel: 'Colonoscopia quando indicada',
+    pageTitle: 'Specta Endoscopia Digestiva',
+    metaTitle: 'Specta Endoscopia Digestiva | Atendimento com Dra. Ana Luiza Rocha',
+    metaDescription:
+      'Colonoscopia com a Dra. Ana Luiza Rocha na Specta Endoscopia Digestiva, em Curitiba. Veja endereço, orientações de agendamento e contexto do exame.',
+    summary:
+      'Local relacionado à colonoscopia no bairro Mercês.',
+    cardDescription:
+      'Referência para colonoscopia com a Dra. Ana Luiza quando o exame entra na investigação ou no rastreio.',
+    visibleRelationshipText:
+      'A Dra. Ana Luiza Rocha realiza colonoscopia na Specta quando o exame é indicado na avaliação do paciente.',
+    addressLines: ['R. Dom Alberto Gonçalves, 311', 'Mercês, Curitiba - PR'],
+    streetAddress: SPECTA_ENDOSCOPIA.address,
+    neighborhood: SPECTA_ENDOSCOPIA.neighborhood,
+    city: SPECTA_ENDOSCOPIA.city,
+    state: SPECTA_ENDOSCOPIA.state,
+    phoneDisplay: SPECTA_ENDOSCOPIA.phone,
+    phoneHref: createPhoneHref(SPECTA_ENDOSCOPIA.phone),
+    whatsappDisplay: SPECTA_ENDOSCOPIA.phone,
+    whatsappHref: createWhatsAppHref(SPECTA_ENDOSCOPIA.phone, WHATSAPP_COLONOSCOPY_TEXT),
+    mapUrl: SPECTA_ENDOSCOPIA.maps,
+    mapLabel: 'Ver rota para a Specta Endoscopia Digestiva',
+    primaryCtaLabel: 'Agendar colonoscopia',
+    schedulingDescription:
+      'Este local é usado quando a colonoscopia faz parte da investigação de sintomas ou do rastreio recomendado pela Dra. Ana Luiza.',
+    servicesTitle: 'Quando este local costuma ser indicado',
+    services: [
+      'Colonoscopia solicitada após consulta, conforme sintomas, idade, histórico e fatores de risco.',
+      'Exame no contexto de investigação de sangramento, alteração intestinal ou necessidade de rastreio.',
+      'Complemento da avaliação quando o plano de cuidado exige confirmação diagnóstica por exame.',
+    ],
+    overviewParagraphs: [
+      'A Specta Endoscopia Digestiva é o local de referência quando a Dra. Ana Luiza indica colonoscopia como parte da investigação ou da prevenção. O foco aqui é o exame, e não a consulta geral.',
+      'Na prática, a consulta ajuda a definir se a colonoscopia faz sentido. Quando há indicação, o exame é organizado no local apropriado, com orientação específica para esse momento do cuidado.',
+    ],
+    practicalInfo: [
+      'O endereço fica no bairro Mercês, em Curitiba.',
+      'A equipe informa no agendamento como funciona o preparo e os passos práticos antes do exame.',
+      'Quando houver consulta prévia, vale manter os laudos e orientações médicas em mãos para facilitar a organização do exame.',
+    ],
+    relatedTreatments: [
+      {
+        href: '/tratamentos/doencas-inflamatorias-intestinais',
+        label: 'Acompanhamento de doenças inflamatórias intestinais',
+      },
+      {
+        href: '/tratamentos/sindrome-intestino-irritavel',
+        label: 'Síndrome do intestino irritável',
+      },
+      { href: '/tratamentos', label: 'Ver a visão geral dos tratamentos' },
+    ],
+    relatedArticles: [
+      {
+        href: '/blog/cancer-colorretal-rastreio-prevencao-diagnostico-precoce',
+        label: 'Quando a colonoscopia entra no rastreio do câncer colorretal',
+      },
+      {
+        href: '/blog/sangue-nas-fezes-quando-procurar-coloproctologista',
+        label: 'Sangue nas fezes: quando investigar',
+      },
+    ],
+    faq: [
+      {
+        question: 'A Specta é o local das consultas em coloproctologia?',
+        answer:
+          'Não. A Specta aparece no site como o local relacionado à colonoscopia quando esse exame é indicado. A consulta clínica e o acompanhamento geral são organizados em contexto próprio.',
+      },
+      {
+        question: 'Toda pessoa atendida pela Dra. Ana precisa de colonoscopia?',
+        answer:
+          'Não. A colonoscopia é indicada de forma individualizada, de acordo com sintomas, idade, histórico e objetivo da investigação.',
+      },
+      {
+        question: 'Como agendar a colonoscopia na Specta?',
+        answer:
+          'O agendamento pode ser iniciado pelo contato exibido nesta página. A equipe orienta os próximos passos, inclusive preparo e horário quando o exame é confirmado.',
+      },
+    ],
+    schemaDescription:
+      'Local em Curitiba relacionado à colonoscopia com a Dra. Ana Luiza Rocha quando o exame é indicado na investigação ou prevenção.',
+    schemaServices: [
+      {
+        name: 'Colonoscopia',
+        description:
+          'Exame endoscópico realizado com a Dra. Ana Luiza Rocha quando há indicação clínica ou preventiva.',
+      },
+    ],
+  },
+]
+
+export function getLocationBySlug(slug: string) {
+  return locationPages.find((location) => location.slug === slug)
+}
+
+export function getLocationPath(slug: string) {
+  return `${LOCATIONS_BASE_PATH}/${slug}`
+}
+
+function getLocationSchemaId(slug: string) {
+  return `${WEBSITE_URL}${getLocationPath(slug)}#place`
+}
+
+function getLocationPageUrl(slug: string) {
+  return `${WEBSITE_URL}${getLocationPath(slug)}`
+}
+
+function getPostalAddress(location: LocationPageData) {
+  return {
+    '@type': 'PostalAddress',
+    streetAddress: location.streetAddress,
+    addressLocality: location.city,
+    addressRegion: location.state,
+    addressCountry: 'BR',
+    ...(location.postalCode ? { postalCode: location.postalCode } : {}),
+  }
+}
+
+function getServiceSchema(service: LocationService) {
+  return {
+    '@type': 'Service',
+    name: service.name,
+    description: service.description,
+    provider: {
+      '@id': `${WEBSITE_URL}/#physician`,
+    },
+    areaServed: {
+      '@type': 'City',
+      name: 'Curitiba',
+    },
+  }
+}
+
+function getLocationSchema(location: LocationPageData) {
+  return {
+    '@type': 'MedicalClinic',
+    '@id': getLocationSchemaId(location.slug),
+    name: location.name,
+    description: location.schemaDescription,
+    url: getLocationPageUrl(location.slug),
+    telephone: location.phoneDisplay,
+    address: getPostalAddress(location),
+    hasMap: location.mapUrl,
+    availableService: location.schemaServices.map(getServiceSchema),
+    ...(location.clinicWebsite ? { sameAs: [location.clinicWebsite] } : {}),
+  }
+}
+
+export function getHomeLocationsStructuredData() {
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'Physician',
+        '@id': `${WEBSITE_URL}/#physician`,
+        name: DR_NAME,
+        url: WEBSITE_URL,
+        medicalSpecialty: ['Coloproctologia', 'Proctologia'],
+        workLocation: locationPages.map((location) => ({
+          '@id': getLocationSchemaId(location.slug),
+        })),
+      },
+      ...locationPages.map(getLocationSchema),
+    ],
+  })
+}
+
+export function getLocationsIndexStructuredData() {
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'CollectionPage',
+        '@id': `${WEBSITE_URL}${LOCATIONS_BASE_PATH}#webpage`,
+        url: `${WEBSITE_URL}${LOCATIONS_BASE_PATH}`,
+        name: 'Locais de atendimento da Dra. Ana Luiza Rocha',
+        description:
+          'Página que reúne os locais de atendimento e exame relacionados à Dra. Ana Luiza Rocha em Curitiba.',
+        about: [
+          {
+            '@id': `${WEBSITE_URL}/#physician`,
+          },
+        ],
+      },
+      {
+        '@type': 'ItemList',
+        itemListElement: locationPages.map((location, index) => ({
+          '@type': 'ListItem',
+          position: index + 1,
+          url: getLocationPageUrl(location.slug),
+          name: location.name,
+        })),
+      },
+      {
+        '@type': 'Physician',
+        '@id': `${WEBSITE_URL}/#physician`,
+        name: DR_NAME,
+        url: WEBSITE_URL,
+        workLocation: locationPages.map((location) => ({
+          '@id': getLocationSchemaId(location.slug),
+        })),
+      },
+      ...locationPages.map(getLocationSchema),
+      generateBreadcrumbSchema([
+        { label: 'Início', href: '/' },
+        { label: 'Locais de atendimento' },
+      ]),
+    ],
+  })
+}
+
+export function getLocationPageStructuredData(location: LocationPageData) {
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'WebPage',
+        '@id': `${getLocationPageUrl(location.slug)}#webpage`,
+        url: getLocationPageUrl(location.slug),
+        name: location.metaTitle,
+        description: location.metaDescription,
+        about: [
+          {
+            '@id': `${WEBSITE_URL}/#physician`,
+          },
+          {
+            '@id': getLocationSchemaId(location.slug),
+          },
+        ],
+      },
+      {
+        '@type': 'Physician',
+        '@id': `${WEBSITE_URL}/#physician`,
+        name: DR_NAME,
+        url: WEBSITE_URL,
+        medicalSpecialty: ['Coloproctologia', 'Proctologia'],
+        workLocation: [
+          {
+            '@id': getLocationSchemaId(location.slug),
+          },
+        ],
+      },
+      getLocationSchema(location),
+      generateBreadcrumbSchema([
+        { label: 'Início', href: '/' },
+        { label: 'Locais de atendimento', href: LOCATIONS_BASE_PATH },
+        { label: location.name },
+      ]),
+    ],
+  })
+}

--- a/src/lib/locations.ts
+++ b/src/lib/locations.ts
@@ -72,7 +72,7 @@ export const locationPages: LocationPageData[] = [
   {
     slug: 'clinica-nassif',
     name: CLINICA_NASSIF.name,
-    shortName: 'Clínica Nassif',
+    shortName: CLINICA_NASSIF.shortName,
     badgeLabel: 'Consulta em coloproctologia',
     pageTitle: 'Clínica Nassif',
     metaTitle: 'Clínica Nassif | Onde a Dra. Ana Luiza Rocha atende em Curitiba',
@@ -155,18 +155,17 @@ export const locationPages: LocationPageData[] = [
   {
     slug: 'specta-endoscopia-digestiva',
     name: SPECTA_ENDOSCOPIA.name,
-    shortName: 'Specta Endoscopia Digestiva',
+    shortName: SPECTA_ENDOSCOPIA.shortName,
     badgeLabel: 'Colonoscopia quando indicada',
     pageTitle: 'Specta Endoscopia Digestiva',
-    metaTitle: 'Specta Endoscopia Digestiva | Atendimento com Dra. Ana Luiza Rocha',
+    metaTitle: 'Specta Endoscopia Digestiva | Colonoscopia com a Dra. Ana Luiza Rocha',
     metaDescription:
-      'Colonoscopia com a Dra. Ana Luiza Rocha na Specta Endoscopia Digestiva, em Curitiba. Veja endereço, orientações de agendamento e contexto do exame.',
-    summary:
-      'Local relacionado à colonoscopia no bairro Mercês.',
+      'Colonoscopia com a Dra. Ana Luiza Rocha na Specta Endoscopia Digestiva, em Curitiba. Veja endereço, como agendar e quando o exame pode ser indicado.',
+    summary: 'Local onde a colonoscopia é realizada quando indicada.',
     cardDescription:
       'Referência para colonoscopia com a Dra. Ana Luiza quando o exame entra na investigação ou no rastreio.',
     visibleRelationshipText:
-      'A Dra. Ana Luiza Rocha realiza colonoscopia na Specta quando o exame é indicado na avaliação do paciente.',
+      'A Dra. Ana Luiza Rocha realiza colonoscopia na Specta quando há indicação para o exame após avaliação clínica.',
     addressLines: ['R. Dom Alberto Gonçalves, 311', 'Mercês, Curitiba - PR'],
     streetAddress: SPECTA_ENDOSCOPIA.address,
     neighborhood: SPECTA_ENDOSCOPIA.neighborhood,
@@ -180,7 +179,7 @@ export const locationPages: LocationPageData[] = [
     mapLabel: 'Ver rota para a Specta Endoscopia Digestiva',
     primaryCtaLabel: 'Agendar colonoscopia',
     schedulingDescription:
-      'Este local é usado quando a colonoscopia faz parte da investigação de sintomas ou do rastreio recomendado pela Dra. Ana Luiza.',
+      'Este local é indicado quando a colonoscopia faz parte da investigação de sintomas ou do rastreio recomendado pela Dra. Ana Luiza.',
     servicesTitle: 'Quando este local costuma ser indicado',
     services: [
       'Colonoscopia solicitada após consulta, conforme sintomas, idade, histórico e fatores de risco.',
@@ -188,8 +187,8 @@ export const locationPages: LocationPageData[] = [
       'Complemento da avaliação quando o plano de cuidado exige confirmação diagnóstica por exame.',
     ],
     overviewParagraphs: [
-      'A Specta Endoscopia Digestiva é o local de referência quando a Dra. Ana Luiza indica colonoscopia como parte da investigação ou da prevenção. O foco aqui é o exame, e não a consulta geral.',
-      'Na prática, a consulta ajuda a definir se a colonoscopia faz sentido. Quando há indicação, o exame é organizado no local apropriado, com orientação específica para esse momento do cuidado.',
+      'A Specta Endoscopia Digestiva é o local onde a Dra. Ana Luiza realiza a colonoscopia quando o exame é indicado como parte da investigação ou da prevenção. Aqui, o foco é o exame, e não as consultas de rotina.',
+      'A consulta ajuda a definir se a colonoscopia é necessária. Quando há indicação, o exame é organizado na Specta, com orientações específicas para o preparo e a realização.',
     ],
     practicalInfo: [
       'O endereço fica no bairro Mercês, em Curitiba.',
@@ -219,9 +218,9 @@ export const locationPages: LocationPageData[] = [
     ],
     faq: [
       {
-        question: 'A Specta é o local das consultas em coloproctologia?',
+        question: `As consultas são realizadas na ${SPECTA_ENDOSCOPIA.shortName}?`,
         answer:
-          'Não. A Specta aparece no site como o local relacionado à colonoscopia quando esse exame é indicado. A consulta clínica e o acompanhamento geral são organizados em contexto próprio.',
+          `Não. As consultas e o acompanhamento clínico são realizados na ${CLINICA_NASSIF.shortName}. A ${SPECTA_ENDOSCOPIA.shortName} é o local onde a colonoscopia é realizada quando esse exame é indicado.`,
       },
       {
         question: 'Toda pessoa atendida pela Dra. Ana precisa de colonoscopia?',
@@ -231,7 +230,7 @@ export const locationPages: LocationPageData[] = [
       {
         question: 'Como agendar a colonoscopia na Specta?',
         answer:
-          'O agendamento pode ser iniciado pelo contato exibido nesta página. A equipe orienta os próximos passos, inclusive preparo e horário quando o exame é confirmado.',
+          'O agendamento pode ser iniciado pelo contato exibido nesta página. A equipe orienta os próximos passos, incluindo preparo, data e horário quando o exame é confirmado.',
       },
     ],
     schemaDescription:

--- a/src/lib/locations.ts
+++ b/src/lib/locations.ts
@@ -289,7 +289,7 @@ function getServiceSchema(service: LocationService) {
   }
 }
 
-function getLocationSchema(location: LocationPageData) {
+export function getLocationSchema(location: LocationPageData) {
   return {
     '@type': 'MedicalClinic',
     '@id': getLocationSchemaId(location.slug),
@@ -313,7 +313,6 @@ export function getHomeLocationsStructuredData() {
         '@id': `${WEBSITE_URL}/#physician`,
         name: DR_NAME,
         url: WEBSITE_URL,
-        medicalSpecialty: ['Coloproctologia', 'Proctologia'],
         workLocation: locationPages.map((location) => ({
           '@id': getLocationSchemaId(location.slug),
         })),
@@ -391,7 +390,6 @@ export function getLocationPageStructuredData(location: LocationPageData) {
         '@id': `${WEBSITE_URL}/#physician`,
         name: DR_NAME,
         url: WEBSITE_URL,
-        medicalSpecialty: ['Coloproctologia', 'Proctologia'],
         workLocation: [
           {
             '@id': getLocationSchemaId(location.slug),

--- a/src/lib/locations.ts
+++ b/src/lib/locations.ts
@@ -6,7 +6,7 @@ import {
   WHATSAPP_MSG_TEXT_ENCODED,
   WPP_NUMBER_NASSIF,
 } from './constants'
-import { generateBreadcrumbSchema, type FAQItem } from './seo-schemas'
+import { generateBreadcrumbSchema, generateFAQSchema, type FAQItem } from './seo-schemas'
 
 export const LOCATIONS_BASE_PATH = '/locais-de-atendimento'
 
@@ -74,8 +74,8 @@ export const locationPages: LocationPageData[] = [
     name: CLINICA_NASSIF.name,
     shortName: CLINICA_NASSIF.shortName,
     badgeLabel: 'Consulta em coloproctologia',
-    pageTitle: 'Clínica Nassif',
-    metaTitle: 'Clínica Nassif | Onde a Dra. Ana Luiza Rocha atende em Curitiba',
+    pageTitle: CLINICA_NASSIF.name,
+    metaTitle: 'Clínica Nassif | Proctologia em Curitiba',
     metaDescription:
       'Consultas em coloproctologia com a Dra. Ana Luiza Rocha na Clínica Nassif, no Batel, em Curitiba. Veja endereço, como agendar e tratamentos relacionados.',
     summary: 'Consultas, retornos e acompanhamento no Batel.',
@@ -146,8 +146,7 @@ export const locationPages: LocationPageData[] = [
       },
       {
         name: 'Retorno e acompanhamento',
-        description:
-          'Seguimento clínico e pós-tratamento em doenças do intestino, reto e ânus.',
+        description: 'Seguimento clínico e pós-tratamento em doenças do intestino, reto e ânus.',
       },
     ],
     clinicWebsite: CLINICA_NASSIF.website,
@@ -157,8 +156,8 @@ export const locationPages: LocationPageData[] = [
     name: SPECTA_ENDOSCOPIA.name,
     shortName: SPECTA_ENDOSCOPIA.shortName,
     badgeLabel: 'Colonoscopia quando indicada',
-    pageTitle: 'Specta Endoscopia Digestiva',
-    metaTitle: 'Specta Endoscopia Digestiva | Colonoscopia com a Dra. Ana Luiza Rocha',
+    pageTitle: SPECTA_ENDOSCOPIA.name,
+    metaTitle: 'Specta Endoscopia Digestiva | Colonoscopia em Curitiba',
     metaDescription:
       'Colonoscopia com a Dra. Ana Luiza Rocha na Specta Endoscopia Digestiva, em Curitiba. Veja endereço, como agendar e quando o exame pode ser indicado.',
     summary: 'Local onde a colonoscopia é realizada quando indicada.',
@@ -219,8 +218,7 @@ export const locationPages: LocationPageData[] = [
     faq: [
       {
         question: `As consultas são realizadas na ${SPECTA_ENDOSCOPIA.shortName}?`,
-        answer:
-          `Não. As consultas e o acompanhamento clínico são realizados na ${CLINICA_NASSIF.shortName}. A ${SPECTA_ENDOSCOPIA.shortName} é o local onde a colonoscopia é realizada quando esse exame é indicado.`,
+        answer: `Não. As consultas e o acompanhamento clínico são realizados na ${CLINICA_NASSIF.shortName}. A ${SPECTA_ENDOSCOPIA.shortName} é o local onde a colonoscopia é realizada quando esse exame é indicado.`,
       },
       {
         question: 'Toda pessoa atendida pela Dra. Ana precisa de colonoscopia?',
@@ -403,4 +401,8 @@ export function getLocationPageStructuredData(location: LocationPageData) {
       ]),
     ],
   })
+}
+
+export function getLocationFAQStructuredData(location: LocationPageData) {
+  return JSON.stringify(generateFAQSchema(location.faq))
 }

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -13,7 +13,7 @@ import {
   HOSPITAL_CLINIC_BARCELONA,
   WPP_NUMBER_NASSIF_FORMATTED,
 } from './constants'
-import { locationPages, getLocationPath } from './locations'
+import { locationPages, getLocationPath, getLocationSchema } from './locations'
 
 const structuredData = {
   '@context': 'https://schema.org',
@@ -117,6 +117,9 @@ const structuredData = {
       // schema.org MedicalSpecialty requires enum URIs, not free-text strings
       medicalSpecialty: ['https://schema.org/Gastroenterologic', 'https://schema.org/Surgical'],
     },
+    // MedicalClinic nodes included in global graph so all pages carry
+    // the concrete clinic entity data (address, services), not just @id refs
+    ...locationPages.map(getLocationSchema),
     {
       '@type': 'WebSite',
       '@id': `${WEBSITE_URL}/#website`,

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -29,8 +29,6 @@ const structuredData = {
       areaServed: {
         '@type': 'City',
         name: 'Curitiba',
-        addressRegion: 'Paraná',
-        addressCountry: 'Brasil',
       },
       location: locationPages.map((location) => ({
         '@id': `${WEBSITE_URL}${getLocationPath(location.slug)}#place`,
@@ -40,7 +38,6 @@ const structuredData = {
       '@type': 'Physician',
       '@id': `${WEBSITE_URL}/#physician`,
       name: DR_NAME,
-      jobTitle: 'Coloproctologista',
       description: PHYSICIAN_DESCRIPTION,
       image: `${WEBSITE_URL}/images/og.png`,
       url: WEBSITE_URL,
@@ -65,6 +62,12 @@ const structuredData = {
           '@type': 'EducationalOrganization',
           name: HOSPITAL_CLINIC_BARCELONA,
           description: 'Fellow em Cirurgia Colorretal',
+        },
+      ],
+      memberOf: [
+        {
+          '@type': 'Organization',
+          name: 'International Anal Neoplasia Society (IANS)',
         },
       ],
       hasCredential: [
@@ -92,13 +95,27 @@ const structuredData = {
           },
         },
       ],
+      // availableService is valid on Physician per schema.org
+      availableService: [
+        { '@type': 'MedicalTherapy', name: 'Cirurgias a laser' },
+        { '@type': 'MedicalTherapy', name: 'Toxina botulínica para fissura anal' },
+        { '@type': 'MedicalTherapy', name: 'Cirurgias para fístulas anorretais' },
+        { '@type': 'MedicalProcedure', name: 'Ligadura elástica para hemorroidas' },
+        { '@type': 'MedicalTherapy', name: 'Tratamento de HPV anal' },
+        { '@type': 'MedicalTherapy', name: 'Cirurgia de cisto pilonidal' },
+        { '@type': 'MedicalTherapy', name: 'Acompanhamento de doenças inflamatórias intestinais' },
+        { '@type': 'MedicalTherapy', name: 'Tratamento da síndrome do intestino irritável' },
+        { '@type': 'MedicalProcedure', name: 'Rastreio e prevenção do câncer de canal anal' },
+        { '@type': 'MedicalTest', name: 'Colonoscopia quando indicada' },
+      ],
       worksFor: {
         '@id': `${WEBSITE_URL}/#organization`,
       },
       workLocation: locationPages.map((location) => ({
         '@id': `${WEBSITE_URL}${getLocationPath(location.slug)}#place`,
       })),
-      medicalSpecialty: ['Coloproctologia', 'Cirurgia Colorretal', 'Proctologia'],
+      // schema.org MedicalSpecialty requires enum URIs, not free-text strings
+      medicalSpecialty: ['https://schema.org/Gastroenterologic', 'https://schema.org/Surgical'],
     },
     {
       '@type': 'WebSite',

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -1,26 +1,23 @@
 import {
   DR_NAME,
-  CLINICA_NASSIF,
-  WPP_NUMBER_NASSIF_FORMATTED,
-  WEBSITE_URL,
-  URL_INSTAGRAM,
   ORG_DESCRIPTION,
   PHYSICIAN_DESCRIPTION,
-  SERVICES_DESCRIPTION,
+  WEBSITE_URL,
+  URL_INSTAGRAM,
   WEBSITE_DESCRIPTION,
-  BUSINESS_DESCRIPTION,
   CRM_NUMBER,
   RQE_NUMBER,
   PUC_PR,
   HOSPITAL_SANTA_CASA,
   HOSPITAL_MACKENZIE,
   HOSPITAL_CLINIC_BARCELONA,
+  WPP_NUMBER_NASSIF_FORMATTED,
 } from './constants'
+import { locationPages, getLocationPath } from './locations'
 
-export const structuredData = {
+const structuredData = {
   '@context': 'https://schema.org',
   '@graph': [
-    // Medical Organization
     {
       '@type': 'MedicalOrganization',
       '@id': `${WEBSITE_URL}/#organization`,
@@ -28,45 +25,17 @@ export const structuredData = {
       url: WEBSITE_URL,
       logo: `${WEBSITE_URL}/images/og.png`,
       description: ORG_DESCRIPTION,
-      address: {
-        '@type': 'PostalAddress',
-        streetAddress: CLINICA_NASSIF.address,
-        addressLocality: CLINICA_NASSIF.city,
-        addressRegion: CLINICA_NASSIF.state,
-        addressCountry: 'BR',
-        postalCode: CLINICA_NASSIF.cep,
-      },
-      geo: {
-        '@type': 'GeoCoordinates',
-        latitude: CLINICA_NASSIF.coordinates.latitude,
-        longitude: CLINICA_NASSIF.coordinates.longitude,
-      },
       telephone: WPP_NUMBER_NASSIF_FORMATTED,
-      priceRange: '$$',
-      openingHours: CLINICA_NASSIF.openingHours,
       areaServed: {
         '@type': 'City',
         name: 'Curitiba',
         addressRegion: 'Paraná',
         addressCountry: 'Brasil',
       },
-      // Reference to the clinic where she works
-      containedInPlace: {
-        '@type': 'MedicalClinic',
-        name: CLINICA_NASSIF.name,
-        url: CLINICA_NASSIF.website,
-        telephone: CLINICA_NASSIF.phoneFormatted,
-        address: {
-          '@type': 'PostalAddress',
-          streetAddress: CLINICA_NASSIF.address,
-          addressLocality: CLINICA_NASSIF.city,
-          addressRegion: CLINICA_NASSIF.state,
-          addressCountry: 'BR',
-          postalCode: CLINICA_NASSIF.cep,
-        },
-      },
+      location: locationPages.map((location) => ({
+        '@id': `${WEBSITE_URL}${getLocationPath(location.slug)}#place`,
+      })),
     },
-    // Medical Professional
     {
       '@type': 'Physician',
       '@id': `${WEBSITE_URL}/#physician`,
@@ -98,12 +67,6 @@ export const structuredData = {
           description: 'Fellow em Cirurgia Colorretal',
         },
       ],
-      memberOf: [
-        {
-          '@type': 'Organization',
-          name: 'International Anal Neoplasia Society (IANS)',
-        },
-      ],
       hasCredential: [
         {
           '@type': 'EducationalOccupationalCredential',
@@ -129,58 +92,14 @@ export const structuredData = {
           },
         },
       ],
-      // Brazilian payment methods and currency
-      paymentAccepted: ['Dinheiro', 'Cartão de Crédito', 'Cartão de Débito', 'PIX'],
-      currenciesAccepted: 'BRL',
       worksFor: {
         '@id': `${WEBSITE_URL}/#organization`,
       },
-      workLocation: {
-        '@type': 'MedicalClinic',
-        name: CLINICA_NASSIF.name,
-        address: {
-          '@type': 'PostalAddress',
-          streetAddress: CLINICA_NASSIF.address,
-          addressLocality: CLINICA_NASSIF.city,
-          addressRegion: CLINICA_NASSIF.state,
-          addressCountry: 'BR',
-          postalCode: CLINICA_NASSIF.cep,
-        },
-        geo: {
-          '@type': 'GeoCoordinates',
-          latitude: CLINICA_NASSIF.coordinates.latitude,
-          longitude: CLINICA_NASSIF.coordinates.longitude,
-        },
-      },
-      medicalSpecialty: [
-        'Coloproctologia',
-        'Cirurgia Colorretal',
-        'Proctologia',
-        'Gastroenterologia Cirúrgica',
-      ],
+      workLocation: locationPages.map((location) => ({
+        '@id': `${WEBSITE_URL}${getLocationPath(location.slug)}#place`,
+      })),
+      medicalSpecialty: ['Coloproctologia', 'Cirurgia Colorretal', 'Proctologia'],
     },
-    // Medical Services
-    {
-      '@type': 'MedicalProcedure',
-      '@id': `${WEBSITE_URL}/#services`,
-      name: 'Serviços de Coloproctologia',
-      description: SERVICES_DESCRIPTION,
-      procedureType: [
-        'Cirurgias a laser',
-        'Botox para fissura anal',
-        'Cirurgias para fístulas anorretais',
-        'Ligadura elástica para hemorroidas',
-        'Tratamento de HPV',
-        'Cirurgia de cisto pilonidal',
-        'Acompanhamento de doenças inflamatórias intestinais',
-        'Tratamento da síndrome do intestino irritável',
-        'Rastreio e prevenção do câncer de canal anal',
-      ],
-      performer: {
-        '@id': `${WEBSITE_URL}/#physician`,
-      },
-    },
-    // Website
     {
       '@type': 'WebSite',
       '@id': `${WEBSITE_URL}/#website`,
@@ -191,32 +110,6 @@ export const structuredData = {
         '@id': `${WEBSITE_URL}/#organization`,
       },
       inLanguage: 'pt-BR',
-    },
-    // Local Business
-    {
-      '@type': 'LocalBusiness',
-      '@id': `${WEBSITE_URL}/#localbusiness`,
-      name: `${DR_NAME} - Coloproctologia`,
-      description: BUSINESS_DESCRIPTION,
-      address: {
-        '@type': 'PostalAddress',
-        streetAddress: CLINICA_NASSIF.address,
-        addressLocality: CLINICA_NASSIF.city,
-        addressRegion: CLINICA_NASSIF.state,
-        addressCountry: 'BR',
-        postalCode: CLINICA_NASSIF.cep,
-      },
-      geo: {
-        '@type': 'GeoCoordinates',
-        latitude: CLINICA_NASSIF.coordinates.latitude,
-        longitude: CLINICA_NASSIF.coordinates.longitude,
-      },
-      telephone: WPP_NUMBER_NASSIF_FORMATTED,
-      url: WEBSITE_URL,
-      image: `${WEBSITE_URL}/images/og.png`,
-      priceRange: '$$',
-      openingHours: CLINICA_NASSIF.openingHours,
-      hasMap: `https://maps.google.com/?q=${CLINICA_NASSIF.coordinates.latitude},${CLINICA_NASSIF.coordinates.longitude}`,
     },
   ],
 }


### PR DESCRIPTION
## What changed

Adds dedicated location pages to give Google and users crawlable, semantic content about where Dra. Ana Luiza attends.

**New routes:**
- `/locais-de-atendimento` — hub page listing both locations
- `/locais-de-atendimento/clinica-nassif` — consultation + follow-up
- `/locais-de-atendimento/specta-endoscopia-digestiva` — colonoscopy when indicated

**New files:**
- `src/lib/locations.ts` — central data model: content, CTAs, FAQs, JSON-LD generators
- `src/app/locais-de-atendimento/page.tsx` — hub page
- `src/app/locais-de-atendimento/[slug]/page.tsx` — individual location page
- `docs/location-seo-spec-report.md` — audit notes and schema decision log

**Modified files:**
- `src/lib/constants.ts` — adds `SPECTA_ENDOSCOPIA` constant (address, phone, maps URL)
- `src/app/sitemap.ts` — registers the three new routes

## Why

The site had no crawlable content connecting Dra. Ana Luiza to her two service locations. Specta existed only as a hardcoded homepage card with no schema. This PR creates the content foundation that PRs B and C will wire into structured data and navigation.

## Dependencies

None. This is the foundation — **merge before PR B (structured data) and PR C (internal linking)**.

## Validation

- `bun run build` passes
- All three routes statically generated

---

> Part of the split from analuizamrocha/web#40