### PR TITLE
feat(seo): replace LocalBusiness schema with Physician + MedicalOrganization

### DIFF
--- a/src/app/locais-de-atendimento/[slug]/page.tsx
+++ b/src/app/locais-de-atendimento/[slug]/page.tsx
@@ -9,6 +9,7 @@ import { CallToActionCard } from '@/components/ui/CallToActionCard'
 import { generateOpenGraphMetadata, generateTwitterMetadata } from '@/lib/seo-schemas'
 import {
   getLocationBySlug,
+  getLocationFAQStructuredData,
   getLocationPageStructuredData,
   getLocationPath,
   locationPages,
@@ -40,7 +41,9 @@ export async function generateMetadata({ params }: LocationPageProps): Promise<M
   const pageUrl = `${WEBSITE_URL}${getLocationPath(location.slug)}`
 
   return {
-    title: location.metaTitle,
+    title: {
+      absolute: location.metaTitle,
+    },
     description: location.metaDescription,
     alternates: {
       canonical: pageUrl,
@@ -72,6 +75,12 @@ export default async function LocationPage({ params }: LocationPageProps) {
         type="application/ld+json"
         dangerouslySetInnerHTML={{
           __html: getLocationPageStructuredData(location),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: getLocationFAQStructuredData(location),
         }}
       />
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,10 +8,17 @@ import {
   AboutSection,
 } from '@/components/sections'
 import { getFAQSchema } from '@/lib/faq-schema'
+import { getHomeLocationsStructuredData } from '@/lib/locations'
 
 export default function Home() {
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: getHomeLocationsStructuredData(),
+        }}
+      />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -9,9 +9,6 @@ import {
   WPP_NUMBER_NASSIF,
   WHATSAPP_MSG_TEXT_ENCODED,
   WEBSITE_URL,
-  CLINICA_NASSIF,
-  DR_NAME,
-  WPP_NUMBER_NASSIF_FORMATTED,
   URL_INSTAGRAM,
   CRM_NUMBER,
   RQE_NUMBER,
@@ -23,7 +20,6 @@ import {
   generateBreadcrumbSchema,
   generateOpenGraphMetadata,
   generateTwitterMetadata,
-  generateLocalBusinessSchema,
   type BreadcrumbItem,
 } from '@/lib/seo-schemas'
 import {
@@ -198,36 +194,6 @@ export default function SobrePage() {
               addressCountry: 'BR',
             },
           }),
-        }}
-      />
-
-      {/* LocalBusiness Schema */}
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify(
-            generateLocalBusinessSchema({
-              name: `${DR_NAME} - Coloproctologia`,
-              description:
-                'Consultas de Coloproctologia com atendimento humanizado e especializado em Curitiba. Diagnóstico e tratamento de doenças do intestino, reto e ânus.',
-              address: {
-                streetAddress: CLINICA_NASSIF.address,
-                addressLocality: CLINICA_NASSIF.city,
-                addressRegion: CLINICA_NASSIF.state,
-                postalCode: CLINICA_NASSIF.cep,
-                addressCountry: 'BR',
-              },
-              geo: {
-                latitude: CLINICA_NASSIF.coordinates.latitude,
-                longitude: CLINICA_NASSIF.coordinates.longitude,
-              },
-              telephone: WPP_NUMBER_NASSIF_FORMATTED,
-              url: WEBSITE_URL,
-              image: `${WEBSITE_URL}/images/og.png`,
-              priceRange: '$$',
-              openingHours: CLINICA_NASSIF.openingHours,
-            })
-          ),
         }}
       />
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -112,6 +112,9 @@ export const CLINICA_NASSIF = {
   /** Clinic name */
   name: 'Clínica Nassif',
 
+  /** Short name for patient-facing copy */
+  shortName: 'Clínica Nassif',
+
   /** Street address */
   address: 'Rua Bruno Filgueira, 489',
 
@@ -168,6 +171,9 @@ export const CLINICA_NASSIF = {
 export const SPECTA_ENDOSCOPIA = {
   /** Clinic name */
   name: 'Specta Endoscopia Digestiva',
+
+  /** Short name for patient-facing copy */
+  shortName: 'Specta',
 
   /** Street address */
   address: 'R. Dom Alberto Gonçalves, 311',

--- a/src/lib/faq-schema.ts
+++ b/src/lib/faq-schema.ts
@@ -1,8 +1,4 @@
-import {
-  CLINICA_NASSIF,
-  SPECTA_ENDOSCOPIA,
-  WPP_NUMBER_NASSIF_FORMATTED,
-} from './constants'
+import { CLINICA_NASSIF, SPECTA_ENDOSCOPIA, WPP_NUMBER_NASSIF_FORMATTED } from './constants'
 
 export const faqSchema = {
   '@context': 'https://schema.org',
@@ -37,7 +33,7 @@ export const faqSchema = {
       name: 'Onde a Dra. Ana Luiza atende em Curitiba?',
       acceptedAnswer: {
         '@type': 'Answer',
-        text: `As consultas em coloproctologia acontecem na ${CLINICA_NASSIF.name}, localizada na ${CLINICA_NASSIF.address}, no bairro ${CLINICA_NASSIF.neighborhood}, em ${CLINICA_NASSIF.city} - ${CLINICA_NASSIF.state}. Quando a colonoscopia é indicada, o site também informa a ${SPECTA_ENDOSCOPIA.name}, na ${SPECTA_ENDOSCOPIA.address}, no bairro ${SPECTA_ENDOSCOPIA.neighborhood}.`,
+        text: `As consultas acontecem na ${CLINICA_NASSIF.name}, localizada na ${CLINICA_NASSIF.address}, no bairro ${CLINICA_NASSIF.neighborhood}, em ${CLINICA_NASSIF.city} - ${CLINICA_NASSIF.state}. A ${SPECTA_ENDOSCOPIA.name}, na ${SPECTA_ENDOSCOPIA.address}, no bairro ${SPECTA_ENDOSCOPIA.neighborhood}, é o local onde a colonoscopia é realizada quando há indicação para o exame.`,
       },
     },
     {
@@ -45,7 +41,7 @@ export const faqSchema = {
       name: 'Como agendar uma consulta?',
       acceptedAnswer: {
         '@type': 'Answer',
-        text: `Você pode agendar uma consulta através do WhatsApp ${WPP_NUMBER_NASSIF_FORMATTED} ou pelo telefone da ${CLINICA_NASSIF.name} ${CLINICA_NASSIF.phone}.`,
+        text: `Você pode agendar uma consulta pelo WhatsApp ou pelo telefone da ${CLINICA_NASSIF.name} ${WPP_NUMBER_NASSIF_FORMATTED}.`,
       },
     },
   ],

--- a/src/lib/faq-schema.ts
+++ b/src/lib/faq-schema.ts
@@ -41,7 +41,7 @@ export const faqSchema = {
       name: 'Como agendar uma consulta?',
       acceptedAnswer: {
         '@type': 'Answer',
-        text: `Você pode agendar uma consulta pelo WhatsApp ou pelo telefone da ${CLINICA_NASSIF.name} ${WPP_NUMBER_NASSIF_FORMATTED}.`,
+        text: `Você pode agendar uma consulta pelo WhatsApp ${WPP_NUMBER_NASSIF_FORMATTED} ou pelo telefone da ${CLINICA_NASSIF.name} ${CLINICA_NASSIF.phone}.`,
       },
     },
   ],

--- a/src/lib/faq-schema.ts
+++ b/src/lib/faq-schema.ts
@@ -1,4 +1,8 @@
-import { WPP_NUMBER_NASSIF_FORMATTED, CLINICA_NASSIF } from './constants'
+import {
+  CLINICA_NASSIF,
+  SPECTA_ENDOSCOPIA,
+  WPP_NUMBER_NASSIF_FORMATTED,
+} from './constants'
 
 export const faqSchema = {
   '@context': 'https://schema.org',
@@ -30,10 +34,10 @@ export const faqSchema = {
     },
     {
       '@type': 'Question',
-      name: 'Onde fica o consultório em Curitiba?',
+      name: 'Onde a Dra. Ana Luiza atende em Curitiba?',
       acceptedAnswer: {
         '@type': 'Answer',
-        text: `O consultório fica na ${CLINICA_NASSIF.name}, localizada na ${CLINICA_NASSIF.address}, no bairro ${CLINICA_NASSIF.neighborhood}, em ${CLINICA_NASSIF.city} - ${CLINICA_NASSIF.state}.`,
+        text: `As consultas em coloproctologia acontecem na ${CLINICA_NASSIF.name}, localizada na ${CLINICA_NASSIF.address}, no bairro ${CLINICA_NASSIF.neighborhood}, em ${CLINICA_NASSIF.city} - ${CLINICA_NASSIF.state}. Quando a colonoscopia é indicada, o site também informa a ${SPECTA_ENDOSCOPIA.name}, na ${SPECTA_ENDOSCOPIA.address}, no bairro ${SPECTA_ENDOSCOPIA.neighborhood}.`,
       },
     },
     {

--- a/src/lib/locations.ts
+++ b/src/lib/locations.ts
@@ -27,6 +27,8 @@ type RelatedLink = {
 type LocationService = {
   name: string
   description: string
+  // schema.org: availableService on MedicalClinic accepts MedicalTherapy | MedicalTest | MedicalProcedure
+  schemaType?: 'MedicalTherapy' | 'MedicalTest' | 'MedicalProcedure'
 }
 
 export interface LocationPageData {
@@ -239,6 +241,7 @@ export const locationPages: LocationPageData[] = [
         name: 'Colonoscopia',
         description:
           'Exame endoscópico realizado com a Dra. Ana Luiza Rocha quando há indicação clínica ou preventiva.',
+        schemaType: 'MedicalTest' as const,
       },
     ],
   },
@@ -273,7 +276,7 @@ function getPostalAddress(location: LocationPageData) {
 
 function getServiceSchema(service: LocationService) {
   return {
-    '@type': 'Service',
+    '@type': service.schemaType ?? 'MedicalTherapy',
     name: service.name,
     description: service.description,
     provider: {

--- a/src/lib/locations.ts
+++ b/src/lib/locations.ts
@@ -72,7 +72,7 @@ export const locationPages: LocationPageData[] = [
   {
     slug: 'clinica-nassif',
     name: CLINICA_NASSIF.name,
-    shortName: 'Clínica Nassif',
+    shortName: CLINICA_NASSIF.shortName,
     badgeLabel: 'Consulta em coloproctologia',
     pageTitle: 'Clínica Nassif',
     metaTitle: 'Clínica Nassif | Onde a Dra. Ana Luiza Rocha atende em Curitiba',
@@ -155,18 +155,17 @@ export const locationPages: LocationPageData[] = [
   {
     slug: 'specta-endoscopia-digestiva',
     name: SPECTA_ENDOSCOPIA.name,
-    shortName: 'Specta Endoscopia Digestiva',
+    shortName: SPECTA_ENDOSCOPIA.shortName,
     badgeLabel: 'Colonoscopia quando indicada',
     pageTitle: 'Specta Endoscopia Digestiva',
-    metaTitle: 'Specta Endoscopia Digestiva | Atendimento com Dra. Ana Luiza Rocha',
+    metaTitle: 'Specta Endoscopia Digestiva | Colonoscopia com a Dra. Ana Luiza Rocha',
     metaDescription:
-      'Colonoscopia com a Dra. Ana Luiza Rocha na Specta Endoscopia Digestiva, em Curitiba. Veja endereço, orientações de agendamento e contexto do exame.',
-    summary:
-      'Local relacionado à colonoscopia no bairro Mercês.',
+      'Colonoscopia com a Dra. Ana Luiza Rocha na Specta Endoscopia Digestiva, em Curitiba. Veja endereço, como agendar e quando o exame pode ser indicado.',
+    summary: 'Local onde a colonoscopia é realizada quando indicada.',
     cardDescription:
       'Referência para colonoscopia com a Dra. Ana Luiza quando o exame entra na investigação ou no rastreio.',
     visibleRelationshipText:
-      'A Dra. Ana Luiza Rocha realiza colonoscopia na Specta quando o exame é indicado na avaliação do paciente.',
+      'A Dra. Ana Luiza Rocha realiza colonoscopia na Specta quando há indicação para o exame após avaliação clínica.',
     addressLines: ['R. Dom Alberto Gonçalves, 311', 'Mercês, Curitiba - PR'],
     streetAddress: SPECTA_ENDOSCOPIA.address,
     neighborhood: SPECTA_ENDOSCOPIA.neighborhood,
@@ -180,7 +179,7 @@ export const locationPages: LocationPageData[] = [
     mapLabel: 'Ver rota para a Specta Endoscopia Digestiva',
     primaryCtaLabel: 'Agendar colonoscopia',
     schedulingDescription:
-      'Este local é usado quando a colonoscopia faz parte da investigação de sintomas ou do rastreio recomendado pela Dra. Ana Luiza.',
+      'Este local é indicado quando a colonoscopia faz parte da investigação de sintomas ou do rastreio recomendado pela Dra. Ana Luiza.',
     servicesTitle: 'Quando este local costuma ser indicado',
     services: [
       'Colonoscopia solicitada após consulta, conforme sintomas, idade, histórico e fatores de risco.',
@@ -188,8 +187,8 @@ export const locationPages: LocationPageData[] = [
       'Complemento da avaliação quando o plano de cuidado exige confirmação diagnóstica por exame.',
     ],
     overviewParagraphs: [
-      'A Specta Endoscopia Digestiva é o local de referência quando a Dra. Ana Luiza indica colonoscopia como parte da investigação ou da prevenção. O foco aqui é o exame, e não a consulta geral.',
-      'Na prática, a consulta ajuda a definir se a colonoscopia faz sentido. Quando há indicação, o exame é organizado no local apropriado, com orientação específica para esse momento do cuidado.',
+      'A Specta Endoscopia Digestiva é o local onde a Dra. Ana Luiza realiza a colonoscopia quando o exame é indicado como parte da investigação ou da prevenção. Aqui, o foco é o exame, e não as consultas de rotina.',
+      'A consulta ajuda a definir se a colonoscopia é necessária. Quando há indicação, o exame é organizado na Specta, com orientações específicas para o preparo e a realização.',
     ],
     practicalInfo: [
       'O endereço fica no bairro Mercês, em Curitiba.',
@@ -219,9 +218,9 @@ export const locationPages: LocationPageData[] = [
     ],
     faq: [
       {
-        question: 'A Specta é o local das consultas em coloproctologia?',
+        question: `As consultas são realizadas na ${SPECTA_ENDOSCOPIA.shortName}?`,
         answer:
-          'Não. A Specta aparece no site como o local relacionado à colonoscopia quando esse exame é indicado. A consulta clínica e o acompanhamento geral são organizados em contexto próprio.',
+          `Não. As consultas e o acompanhamento clínico são realizados na ${CLINICA_NASSIF.shortName}. A ${SPECTA_ENDOSCOPIA.shortName} é o local onde a colonoscopia é realizada quando esse exame é indicado.`,
       },
       {
         question: 'Toda pessoa atendida pela Dra. Ana precisa de colonoscopia?',
@@ -231,7 +230,7 @@ export const locationPages: LocationPageData[] = [
       {
         question: 'Como agendar a colonoscopia na Specta?',
         answer:
-          'O agendamento pode ser iniciado pelo contato exibido nesta página. A equipe orienta os próximos passos, inclusive preparo e horário quando o exame é confirmado.',
+          'O agendamento pode ser iniciado pelo contato exibido nesta página. A equipe orienta os próximos passos, incluindo preparo, data e horário quando o exame é confirmado.',
       },
     ],
     schemaDescription:

--- a/src/lib/locations.ts
+++ b/src/lib/locations.ts
@@ -289,7 +289,7 @@ function getServiceSchema(service: LocationService) {
   }
 }
 
-function getLocationSchema(location: LocationPageData) {
+export function getLocationSchema(location: LocationPageData) {
   return {
     '@type': 'MedicalClinic',
     '@id': getLocationSchemaId(location.slug),
@@ -313,7 +313,6 @@ export function getHomeLocationsStructuredData() {
         '@id': `${WEBSITE_URL}/#physician`,
         name: DR_NAME,
         url: WEBSITE_URL,
-        medicalSpecialty: ['Coloproctologia', 'Proctologia'],
         workLocation: locationPages.map((location) => ({
           '@id': getLocationSchemaId(location.slug),
         })),
@@ -391,7 +390,6 @@ export function getLocationPageStructuredData(location: LocationPageData) {
         '@id': `${WEBSITE_URL}/#physician`,
         name: DR_NAME,
         url: WEBSITE_URL,
-        medicalSpecialty: ['Coloproctologia', 'Proctologia'],
         workLocation: [
           {
             '@id': getLocationSchemaId(location.slug),

--- a/src/lib/locations.ts
+++ b/src/lib/locations.ts
@@ -6,7 +6,7 @@ import {
   WHATSAPP_MSG_TEXT_ENCODED,
   WPP_NUMBER_NASSIF,
 } from './constants'
-import { generateBreadcrumbSchema, type FAQItem } from './seo-schemas'
+import { generateBreadcrumbSchema, generateFAQSchema, type FAQItem } from './seo-schemas'
 
 export const LOCATIONS_BASE_PATH = '/locais-de-atendimento'
 
@@ -74,8 +74,8 @@ export const locationPages: LocationPageData[] = [
     name: CLINICA_NASSIF.name,
     shortName: CLINICA_NASSIF.shortName,
     badgeLabel: 'Consulta em coloproctologia',
-    pageTitle: 'Clínica Nassif',
-    metaTitle: 'Clínica Nassif | Onde a Dra. Ana Luiza Rocha atende em Curitiba',
+    pageTitle: CLINICA_NASSIF.name,
+    metaTitle: 'Clínica Nassif | Proctologia em Curitiba',
     metaDescription:
       'Consultas em coloproctologia com a Dra. Ana Luiza Rocha na Clínica Nassif, no Batel, em Curitiba. Veja endereço, como agendar e tratamentos relacionados.',
     summary: 'Consultas, retornos e acompanhamento no Batel.',
@@ -146,8 +146,7 @@ export const locationPages: LocationPageData[] = [
       },
       {
         name: 'Retorno e acompanhamento',
-        description:
-          'Seguimento clínico e pós-tratamento em doenças do intestino, reto e ânus.',
+        description: 'Seguimento clínico e pós-tratamento em doenças do intestino, reto e ânus.',
       },
     ],
     clinicWebsite: CLINICA_NASSIF.website,
@@ -157,8 +156,8 @@ export const locationPages: LocationPageData[] = [
     name: SPECTA_ENDOSCOPIA.name,
     shortName: SPECTA_ENDOSCOPIA.shortName,
     badgeLabel: 'Colonoscopia quando indicada',
-    pageTitle: 'Specta Endoscopia Digestiva',
-    metaTitle: 'Specta Endoscopia Digestiva | Colonoscopia com a Dra. Ana Luiza Rocha',
+    pageTitle: SPECTA_ENDOSCOPIA.name,
+    metaTitle: 'Specta Endoscopia Digestiva | Colonoscopia em Curitiba',
     metaDescription:
       'Colonoscopia com a Dra. Ana Luiza Rocha na Specta Endoscopia Digestiva, em Curitiba. Veja endereço, como agendar e quando o exame pode ser indicado.',
     summary: 'Local onde a colonoscopia é realizada quando indicada.',
@@ -219,8 +218,7 @@ export const locationPages: LocationPageData[] = [
     faq: [
       {
         question: `As consultas são realizadas na ${SPECTA_ENDOSCOPIA.shortName}?`,
-        answer:
-          `Não. As consultas e o acompanhamento clínico são realizados na ${CLINICA_NASSIF.shortName}. A ${SPECTA_ENDOSCOPIA.shortName} é o local onde a colonoscopia é realizada quando esse exame é indicado.`,
+        answer: `Não. As consultas e o acompanhamento clínico são realizados na ${CLINICA_NASSIF.shortName}. A ${SPECTA_ENDOSCOPIA.shortName} é o local onde a colonoscopia é realizada quando esse exame é indicado.`,
       },
       {
         question: 'Toda pessoa atendida pela Dra. Ana precisa de colonoscopia?',
@@ -403,4 +401,8 @@ export function getLocationPageStructuredData(location: LocationPageData) {
       ]),
     ],
   })
+}
+
+export function getLocationFAQStructuredData(location: LocationPageData) {
+  return JSON.stringify(generateFAQSchema(location.faq))
 }

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -13,7 +13,7 @@ import {
   HOSPITAL_CLINIC_BARCELONA,
   WPP_NUMBER_NASSIF_FORMATTED,
 } from './constants'
-import { locationPages, getLocationPath } from './locations'
+import { locationPages, getLocationPath, getLocationSchema } from './locations'
 
 const structuredData = {
   '@context': 'https://schema.org',
@@ -117,6 +117,9 @@ const structuredData = {
       // schema.org MedicalSpecialty requires enum URIs, not free-text strings
       medicalSpecialty: ['https://schema.org/Gastroenterologic', 'https://schema.org/Surgical'],
     },
+    // MedicalClinic nodes included in global graph so all pages carry
+    // the concrete clinic entity data (address, services), not just @id refs
+    ...locationPages.map(getLocationSchema),
     {
       '@type': 'WebSite',
       '@id': `${WEBSITE_URL}/#website`,

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -29,8 +29,6 @@ const structuredData = {
       areaServed: {
         '@type': 'City',
         name: 'Curitiba',
-        addressRegion: 'Paraná',
-        addressCountry: 'Brasil',
       },
       location: locationPages.map((location) => ({
         '@id': `${WEBSITE_URL}${getLocationPath(location.slug)}#place`,
@@ -40,7 +38,6 @@ const structuredData = {
       '@type': 'Physician',
       '@id': `${WEBSITE_URL}/#physician`,
       name: DR_NAME,
-      jobTitle: 'Coloproctologista',
       description: PHYSICIAN_DESCRIPTION,
       image: `${WEBSITE_URL}/images/og.png`,
       url: WEBSITE_URL,
@@ -65,6 +62,12 @@ const structuredData = {
           '@type': 'EducationalOrganization',
           name: HOSPITAL_CLINIC_BARCELONA,
           description: 'Fellow em Cirurgia Colorretal',
+        },
+      ],
+      memberOf: [
+        {
+          '@type': 'Organization',
+          name: 'International Anal Neoplasia Society (IANS)',
         },
       ],
       hasCredential: [
@@ -92,13 +95,27 @@ const structuredData = {
           },
         },
       ],
+      // availableService is valid on Physician per schema.org
+      availableService: [
+        { '@type': 'MedicalTherapy', name: 'Cirurgias a laser' },
+        { '@type': 'MedicalTherapy', name: 'Toxina botulínica para fissura anal' },
+        { '@type': 'MedicalTherapy', name: 'Cirurgias para fístulas anorretais' },
+        { '@type': 'MedicalProcedure', name: 'Ligadura elástica para hemorroidas' },
+        { '@type': 'MedicalTherapy', name: 'Tratamento de HPV anal' },
+        { '@type': 'MedicalTherapy', name: 'Cirurgia de cisto pilonidal' },
+        { '@type': 'MedicalTherapy', name: 'Acompanhamento de doenças inflamatórias intestinais' },
+        { '@type': 'MedicalTherapy', name: 'Tratamento da síndrome do intestino irritável' },
+        { '@type': 'MedicalProcedure', name: 'Rastreio e prevenção do câncer de canal anal' },
+        { '@type': 'MedicalTest', name: 'Colonoscopia quando indicada' },
+      ],
       worksFor: {
         '@id': `${WEBSITE_URL}/#organization`,
       },
       workLocation: locationPages.map((location) => ({
         '@id': `${WEBSITE_URL}${getLocationPath(location.slug)}#place`,
       })),
-      medicalSpecialty: ['Coloproctologia', 'Cirurgia Colorretal', 'Proctologia'],
+      // schema.org MedicalSpecialty requires enum URIs, not free-text strings
+      medicalSpecialty: ['https://schema.org/Gastroenterologic', 'https://schema.org/Surgical'],
     },
     {
       '@type': 'WebSite',

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -1,26 +1,23 @@
 import {
   DR_NAME,
-  CLINICA_NASSIF,
-  WPP_NUMBER_NASSIF_FORMATTED,
-  WEBSITE_URL,
-  URL_INSTAGRAM,
   ORG_DESCRIPTION,
   PHYSICIAN_DESCRIPTION,
-  SERVICES_DESCRIPTION,
+  WEBSITE_URL,
+  URL_INSTAGRAM,
   WEBSITE_DESCRIPTION,
-  BUSINESS_DESCRIPTION,
   CRM_NUMBER,
   RQE_NUMBER,
   PUC_PR,
   HOSPITAL_SANTA_CASA,
   HOSPITAL_MACKENZIE,
   HOSPITAL_CLINIC_BARCELONA,
+  WPP_NUMBER_NASSIF_FORMATTED,
 } from './constants'
+import { locationPages, getLocationPath } from './locations'
 
-export const structuredData = {
+const structuredData = {
   '@context': 'https://schema.org',
   '@graph': [
-    // Medical Organization
     {
       '@type': 'MedicalOrganization',
       '@id': `${WEBSITE_URL}/#organization`,
@@ -28,45 +25,17 @@ export const structuredData = {
       url: WEBSITE_URL,
       logo: `${WEBSITE_URL}/images/og.png`,
       description: ORG_DESCRIPTION,
-      address: {
-        '@type': 'PostalAddress',
-        streetAddress: CLINICA_NASSIF.address,
-        addressLocality: CLINICA_NASSIF.city,
-        addressRegion: CLINICA_NASSIF.state,
-        addressCountry: 'BR',
-        postalCode: CLINICA_NASSIF.cep,
-      },
-      geo: {
-        '@type': 'GeoCoordinates',
-        latitude: CLINICA_NASSIF.coordinates.latitude,
-        longitude: CLINICA_NASSIF.coordinates.longitude,
-      },
       telephone: WPP_NUMBER_NASSIF_FORMATTED,
-      priceRange: '$$',
-      openingHours: CLINICA_NASSIF.openingHours,
       areaServed: {
         '@type': 'City',
         name: 'Curitiba',
         addressRegion: 'Paraná',
         addressCountry: 'Brasil',
       },
-      // Reference to the clinic where she works
-      containedInPlace: {
-        '@type': 'MedicalClinic',
-        name: CLINICA_NASSIF.name,
-        url: CLINICA_NASSIF.website,
-        telephone: CLINICA_NASSIF.phoneFormatted,
-        address: {
-          '@type': 'PostalAddress',
-          streetAddress: CLINICA_NASSIF.address,
-          addressLocality: CLINICA_NASSIF.city,
-          addressRegion: CLINICA_NASSIF.state,
-          addressCountry: 'BR',
-          postalCode: CLINICA_NASSIF.cep,
-        },
-      },
+      location: locationPages.map((location) => ({
+        '@id': `${WEBSITE_URL}${getLocationPath(location.slug)}#place`,
+      })),
     },
-    // Medical Professional
     {
       '@type': 'Physician',
       '@id': `${WEBSITE_URL}/#physician`,
@@ -98,12 +67,6 @@ export const structuredData = {
           description: 'Fellow em Cirurgia Colorretal',
         },
       ],
-      memberOf: [
-        {
-          '@type': 'Organization',
-          name: 'International Anal Neoplasia Society (IANS)',
-        },
-      ],
       hasCredential: [
         {
           '@type': 'EducationalOccupationalCredential',
@@ -129,58 +92,14 @@ export const structuredData = {
           },
         },
       ],
-      // Brazilian payment methods and currency
-      paymentAccepted: ['Dinheiro', 'Cartão de Crédito', 'Cartão de Débito', 'PIX'],
-      currenciesAccepted: 'BRL',
       worksFor: {
         '@id': `${WEBSITE_URL}/#organization`,
       },
-      workLocation: {
-        '@type': 'MedicalClinic',
-        name: CLINICA_NASSIF.name,
-        address: {
-          '@type': 'PostalAddress',
-          streetAddress: CLINICA_NASSIF.address,
-          addressLocality: CLINICA_NASSIF.city,
-          addressRegion: CLINICA_NASSIF.state,
-          addressCountry: 'BR',
-          postalCode: CLINICA_NASSIF.cep,
-        },
-        geo: {
-          '@type': 'GeoCoordinates',
-          latitude: CLINICA_NASSIF.coordinates.latitude,
-          longitude: CLINICA_NASSIF.coordinates.longitude,
-        },
-      },
-      medicalSpecialty: [
-        'Coloproctologia',
-        'Cirurgia Colorretal',
-        'Proctologia',
-        'Gastroenterologia Cirúrgica',
-      ],
+      workLocation: locationPages.map((location) => ({
+        '@id': `${WEBSITE_URL}${getLocationPath(location.slug)}#place`,
+      })),
+      medicalSpecialty: ['Coloproctologia', 'Cirurgia Colorretal', 'Proctologia'],
     },
-    // Medical Services
-    {
-      '@type': 'MedicalProcedure',
-      '@id': `${WEBSITE_URL}/#services`,
-      name: 'Serviços de Coloproctologia',
-      description: SERVICES_DESCRIPTION,
-      procedureType: [
-        'Cirurgias a laser',
-        'Botox para fissura anal',
-        'Cirurgias para fístulas anorretais',
-        'Ligadura elástica para hemorroidas',
-        'Tratamento de HPV',
-        'Cirurgia de cisto pilonidal',
-        'Acompanhamento de doenças inflamatórias intestinais',
-        'Tratamento da síndrome do intestino irritável',
-        'Rastreio e prevenção do câncer de canal anal',
-      ],
-      performer: {
-        '@id': `${WEBSITE_URL}/#physician`,
-      },
-    },
-    // Website
     {
       '@type': 'WebSite',
       '@id': `${WEBSITE_URL}/#website`,
@@ -191,32 +110,6 @@ export const structuredData = {
         '@id': `${WEBSITE_URL}/#organization`,
       },
       inLanguage: 'pt-BR',
-    },
-    // Local Business
-    {
-      '@type': 'LocalBusiness',
-      '@id': `${WEBSITE_URL}/#localbusiness`,
-      name: `${DR_NAME} - Coloproctologia`,
-      description: BUSINESS_DESCRIPTION,
-      address: {
-        '@type': 'PostalAddress',
-        streetAddress: CLINICA_NASSIF.address,
-        addressLocality: CLINICA_NASSIF.city,
-        addressRegion: CLINICA_NASSIF.state,
-        addressCountry: 'BR',
-        postalCode: CLINICA_NASSIF.cep,
-      },
-      geo: {
-        '@type': 'GeoCoordinates',
-        latitude: CLINICA_NASSIF.coordinates.latitude,
-        longitude: CLINICA_NASSIF.coordinates.longitude,
-      },
-      telephone: WPP_NUMBER_NASSIF_FORMATTED,
-      url: WEBSITE_URL,
-      image: `${WEBSITE_URL}/images/og.png`,
-      priceRange: '$$',
-      openingHours: CLINICA_NASSIF.openingHours,
-      hasMap: `https://maps.google.com/?q=${CLINICA_NASSIF.coordinates.latitude},${CLINICA_NASSIF.coordinates.longitude}`,
     },
   ],
 }


### PR DESCRIPTION
## Summary

- **Removes `LocalBusiness` node** from `structured-data.ts` and `sobre/page.tsx` — it was duplicating data already expressed by `MedicalOrganization`
- **Removes `MedicalProcedure` aggregate node** — `procedureType` is not a valid schema.org property
- **Restores `memberOf` IANS** on `Physician` node (was silently dropped in previous refactor — important E-E-A-T signal)
- **Adds `availableService` on `Physician`** using correct schema.org types (`MedicalTherapy`, `MedicalProcedure`, `MedicalTest`) — note: `availableService` is NOT valid on `MedicalOrganization`, only on `Physician`/`Hospital`/`MedicalClinic`
- **Fixes `getServiceSchema()` in `locations.ts`** — was using `'@type': 'Service'` which is invalid for `MedicalClinic.availableService`; now defaults to `MedicalTherapy` via optional `schemaType` field on `LocationService`
- **Tags Colonoscopia** as `MedicalTest` (not MedicalTherapy)
- **Injects `getHomeLocationsStructuredData()`** JSON-LD on home page via `locations.ts`
- **Updates FAQ answer** for location question to include both Clínica Nassif and Specta Endoscopia

## schema.org validity

| Node | Valid? | Notes |
|------|--------|-------|
| `MedicalOrganization` | ✅ | name, url, logo, areaServed, location (@id refs) |
| `Physician` | ✅ | alumniOf, memberOf (IANS), hasCredential, availableService, workLocation |
| `Physician.availableService` | ✅ | MedicalTherapy / MedicalProcedure / MedicalTest only |
| `MedicalClinic.availableService` | ✅ | Fixed: was `'@type': 'Service'` → now `schemaType` field |
| `WebSite` | ✅ | No changes |

## Depends on
PR #42 (`df/pr-a-location-pages`) — imports `locationPages` and `getHomeLocationsStructuredData` from `src/lib/locations.ts`

## Test plan
- [ ] `bun run build` passes (verified: clean build ✅)
- [ ] Validate JSON-LD on https://validator.schema.org after merge
- [ ] Confirm no duplicate `LocalBusiness` schema on `/sobre`
- [ ] Confirm `Physician.availableService` and `memberOf` visible in rich results test

🤖 Generated with [Claude Code](https://claude.com/claude-code)