### PR TITLE
feat(nav): wire location pages into navigation, footer, and sections

### DIFF
--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -592,6 +592,14 @@ export default function SobrePage() {
                 >
                   Conhecer tratamentos
                 </LinkButton>
+                <LinkButton
+                  href="/locais-de-atendimento"
+                  size="xl"
+                  variant="subtle"
+                  className="text-lg px-8 py-4 font-semibold text-nowrap shadow-lg hover:shadow-xl transform transition-all duration-300"
+                >
+                  Ver locais de atendimento
+                </LinkButton>
               </>
             }
             variant="secondary"

--- a/src/app/tratamentos/page.tsx
+++ b/src/app/tratamentos/page.tsx
@@ -172,6 +172,10 @@ export default function ServicosPage() {
                 <br />
                 Atendimento humanizado com a mais alta qualidade técnica.
               </p>
+              <p className="text-base lg:text-lg text-secondary/80 leading-relaxed mb-6">
+                Se quiser entender em qual clínica a consulta ou o exame faz mais sentido, veja
+                também os locais de atendimento.
+              </p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center">
                 <LinkButton
                   href={`https://wa.me/${WPP_NUMBER_NASSIF}/?text=${WHATSAPP_MSG_TEXT_ENCODED}`}
@@ -191,6 +195,14 @@ export default function ServicosPage() {
                   className="text-lg px-8 py-4 font-semibold text-nowrap shadow-lg hover:shadow-xl transform  transition-all duration-300"
                 >
                   Artigos educativos
+                </LinkButton>
+                <LinkButton
+                  href="/locais-de-atendimento"
+                  size="xl"
+                  variant="subtle"
+                  className="text-lg px-8 py-4 font-semibold text-nowrap shadow-lg hover:shadow-xl transform transition-all duration-300"
+                >
+                  Ver locais
                 </LinkButton>
               </div>
             </div>

--- a/src/components/sections/AboutSection.tsx
+++ b/src/components/sections/AboutSection.tsx
@@ -74,9 +74,12 @@ export function AboutSection() {
           </div>
         </div>
 
-        <div className="text-center mb-8 lg:mb-4 mt-4 lg:mt-8">
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-8 lg:mb-4 mt-4 lg:mt-8">
           <LinkButton href="/sobre" variant="outline" size="lg">
             Conheça minha trajetória
+          </LinkButton>
+          <LinkButton href="/locais-de-atendimento" variant="subtle" size="lg">
+            Ver locais de atendimento
           </LinkButton>
         </div>
       </div>

--- a/src/components/sections/LocationsSection.tsx
+++ b/src/components/sections/LocationsSection.tsx
@@ -1,41 +1,22 @@
 import { Calendar, MapPin } from 'lucide-react'
-import { CLINICA_NASSIF, WHATSAPP_MSG_TEXT_ENCODED, WPP_NUMBER_NASSIF } from '@/lib/constants'
 import { LinkButton } from '@/components/ui/LinkButton'
+import { getLocationPath, locationPages } from '@/lib/locations'
 
-const WHATSAPP_SPECTA_NUMBER = '(41) 98773-7829'
-const WHATSAPP_SPECTA_MSG_ENCODED = encodeURIComponent(
-  'Olá! Gostaria de agendar minha colonoscopia com a Dra Ana Luiza'
-)
-
-const getWhatsAppHref = (phone: string, messageEncoded: string) =>
-  `https://wa.me/${phone.replace(/\D/g, '')}/?text=${messageEncoded}`
-
-const locations = [
-  {
-    name: CLINICA_NASSIF.name,
-    address: ['Rua Bruno Filgueira, 489', 'Batel, Curitiba - PR'],
-    phone: CLINICA_NASSIF.phone,
-    whatsapp: CLINICA_NASSIF.wpp,
-    whatsappHref: getWhatsAppHref(WPP_NUMBER_NASSIF, WHATSAPP_MSG_TEXT_ENCODED),
-    buttonText: 'Agende sua consulta agora',
-    ariaLabel: 'Agende sua consulta agora com a Dra. Ana Luiza Moraes Rocha por WhatsApp',
-  },
-  {
-    name: 'Specta Endoscopia Digestiva',
-    address: ['R. Dom Alberto Gonçalves, 311', 'Mercês, Curitiba - PR'],
-    phone: WHATSAPP_SPECTA_NUMBER,
-    whatsapp: WHATSAPP_SPECTA_NUMBER,
-    whatsappHref: getWhatsAppHref(WHATSAPP_SPECTA_NUMBER, WHATSAPP_SPECTA_MSG_ENCODED),
-    buttonText: 'Agende sua colonoscopia',
-    ariaLabel: 'Agende sua colonoscopia com a Dra. Ana Luiza por WhatsApp',
-  },
-] as const
+const locations = locationPages.map((location) => ({
+  slug: location.slug,
+  name: location.name,
+  address: location.addressLines,
+  phone: location.phoneDisplay,
+  whatsapp: location.whatsappDisplay,
+  whatsappHref: location.whatsappHref,
+  buttonText: location.primaryCtaLabel,
+  ariaLabel: `${location.primaryCtaLabel} por WhatsApp`,
+}))
 
 export function LocationsSection() {
   return (
     <section id="atendimento" className="section section-deferred bg-background">
       <div className="max-w-[1760px] mx-auto px-6 sm:px-8 lg:px-10 xl:px-12">
-        {/* Header Section - Enhanced Typography */}
         <div className="mx-auto max-w-4xl text-center mb-16 lg:mb-20 animate-fade-in">
           <h2 className="text-4xl sm:text-5xl lg:text-6xl font-serif font-bold text-primary mb-8">
             Locais de atendimento
@@ -45,11 +26,10 @@ export function LocationsSection() {
           </div>
         </div>
 
-        {/* Location Cards */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-10 xl:gap-12">
           {locations.map((location) => (
             <div
-              key={location.name}
+              key={location.slug}
               className="bg-secondary/10 rounded-3xl p-8 lg:p-10 border border-secondary/20 hover:border-secondary/30 transition-all duration-300 shadow-sm hover:shadow-md h-full flex"
             >
               <div className="flex flex-col gap-6 h-full w-full lg:pl-4 xl:pl-6">
@@ -81,21 +61,33 @@ export function LocationsSection() {
                   </div>
                 </div>
 
-                <LinkButton
-                  href={location.whatsappHref}
-                  external
-                  newTab
-                  variant="primary"
-                  size="lg"
-                  className="mt-auto inline-flex items-center justify-center gap-3 w-full sm:w-[22rem] whitespace-nowrap px-6 py-4 text-sm lg:text-base font-semibold rounded-full shadow-md hover:shadow-lg transform hover:scale-[1.02] transition-all duration-300"
-                  aria-label={location.ariaLabel}
-                >
-                  <Calendar className="size-5" />
-                  {location.buttonText}
-                </LinkButton>
+                <div className="mt-auto flex flex-col gap-4">
+                  <LinkButton
+                    href={location.whatsappHref}
+                    external
+                    newTab
+                    variant="primary"
+                    size="lg"
+                    className="inline-flex items-center justify-center gap-3 w-full sm:w-[22rem] whitespace-nowrap px-6 py-4 text-sm lg:text-base font-semibold rounded-full shadow-md hover:shadow-lg transform hover:scale-[1.02] transition-all duration-300"
+                    aria-label={location.ariaLabel}
+                  >
+                    <Calendar className="size-5" />
+                    {location.buttonText}
+                  </LinkButton>
+
+                  <LinkButton href={getLocationPath(location.slug)} variant="link" size="default">
+                    Ver detalhes deste local
+                  </LinkButton>
+                </div>
               </div>
             </div>
           ))}
+        </div>
+
+        <div className="mt-10 text-center">
+          <LinkButton href="/locais-de-atendimento" variant="outline" size="lg">
+            Ver todos os detalhes dos locais
+          </LinkButton>
         </div>
       </div>
     </section>

--- a/src/components/ui/Footer.tsx
+++ b/src/components/ui/Footer.tsx
@@ -49,6 +49,12 @@ export function Footer() {
                 Sobre
               </Link>
               <Link
+                href="/locais-de-atendimento"
+                className="text-background/70 hover:text-background text-sm font-medium transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-background/50 rounded-sm"
+              >
+                Locais
+              </Link>
+              <Link
                 href="/tratamentos"
                 className="text-background/70 hover:text-background text-sm font-medium transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-background/50 rounded-sm"
               >

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -44,6 +44,12 @@ export const globalNavigation: NavigationItem[] = [
   { name: 'Início', href: '/', id: 'home', type: 'route' },
   { name: 'Blog', href: '/blog', id: 'blog', type: 'route' },
   {
+    name: 'Locais',
+    href: '/locais-de-atendimento',
+    id: 'locais',
+    type: 'route',
+  },
+  {
     name: 'Tratamentos',
     href: '/tratamentos',
     id: 'tratamentos',


### PR DESCRIPTION
## What changed

Wires `/locais-de-atendimento` into the existing site navigation and section CTAs:

| Location | Change |
|----------|--------|
| Global nav (Header) | Added "Locais" link |
| Footer | Added "Locais" link |
| `LocationsSection` | Cards now link to individual location detail pages; kept WhatsApp CTA as primary action |
| `AboutSection` | Single "Conheça minha trajetória" button expanded to two buttons (added "Ver locais") |
| `/sobre` CTA block | Added "Ver locais de atendimento" button |
| `/tratamentos` CTA block | Added location reference paragraph + "Ver locais" button |

## Why

The location pages (PR A) are accessible but not linked from anywhere. This PR adds the internal links that make them crawlable and usable.

## Dependencies

**Requires analuizamrocha/web#42 (PR A) merged first** — imports `getLocationPath` and `locationPages` from `src/lib/locations.ts`.

This PR is stacked on the PR A branch. When PR A merges to main, rebase this branch onto main before merging.

Can be merged independently of PR B (structured data).

## Validation

- `bun run build` passes
- Location links resolve correctly

---

> Part of the split from analuizamrocha/web#40