### PR TITLE
feat(seo): add proctologista keyword coverage across metadata and copy

### DIFF
--- a/content/posts/doencas-inflamatorias-intestinais-acompanhamento.md
+++ b/content/posts/doencas-inflamatorias-intestinais-acompanhamento.md
@@ -1,9 +1,9 @@
 ---
 title: 'Doenças inflamatórias intestinais (DII): acompanhamento especializado'
-metaDescription: 'Saiba como funciona o acompanhamento da Doença de Crohn e Retocolite Ulcerativa com monitoramento contínuo, prevenção de complicações e tratamento individualizado.'
+metaDescription: 'Saiba como funciona o acompanhamento da Doença de Crohn e Retocolite Ulcerativa com monitoramento contínuo, prevenção de complicações e tratamento individualizado em Curitiba.'
 slug: 'doencas-inflamatorias-intestinais-acompanhamento'
 publishDate: '2026-03-07'
-lastModified: '2026-03-07'
+lastModified: '2026-04-02'
 primaryKeyword: 'doenças inflamatórias intestinais'
 secondaryKeywords:
   - 'Doença de Crohn'
@@ -11,6 +11,8 @@ secondaryKeywords:
   - 'acompanhamento DII'
   - 'tratamento DII'
   - 'coloproctologista Curitiba'
+  - 'tratamento crohn curitiba'
+  - 'proctologista curitiba'
 targetAudience: 'patients'
 intent: 'consideration'
 featured: false

--- a/content/posts/fissura-anal-toxina-botulinica-tratamento.md
+++ b/content/posts/fissura-anal-toxina-botulinica-tratamento.md
@@ -1,9 +1,9 @@
 ---
 title: 'Fissura anal: toxina botulínica ajuda mesmo?'
-metaDescription: 'Saiba como a toxina botulínica (botox) atua no tratamento da fissura anal crônica, quando é indicada e quais são os benefícios. Coloproctologista em Curitiba.'
+metaDescription: 'Saiba como a toxina botulínica (botox) atua no tratamento da fissura anal crônica, quando é indicada e quais são os benefícios com proctologista em Curitiba.'
 slug: 'fissura-anal-toxina-botulinica-tratamento'
 publishDate: '2026-03-15'
-lastModified: '2026-03-15'
+lastModified: '2026-04-02'
 primaryKeyword: 'toxina botulínica fissura anal'
 secondaryKeywords:
   - 'botox fissura anal'
@@ -11,6 +11,7 @@ secondaryKeywords:
   - 'toxina botulínica coloproctologia'
   - 'fissura anal sem cirurgia'
   - 'coloproctologista Curitiba'
+  - 'proctologista curitiba'
   - 'esfíncter anal relaxamento'
 targetAudience: 'patients'
 intent: 'consideration'

--- a/content/posts/hpv-anal-condilomas-riscos-tratamento-rastreio.md
+++ b/content/posts/hpv-anal-condilomas-riscos-tratamento-rastreio.md
@@ -1,9 +1,9 @@
 ---
 title: 'HPV anal e condilomas: o que são, riscos, tratamento e importância do rastreio'
-metaDescription: 'Entenda HPV anal e condilomas: sintomas, riscos, tratamento, vacina e rastreio para prevenção do câncer anal com coloproctologista em Curitiba.'
+metaDescription: 'Entenda HPV anal e condilomas: sintomas, riscos, tratamento, vacina e rastreio para prevenção do câncer anal com proctologista em Curitiba.'
 slug: 'hpv-anal-condilomas-riscos-tratamento-rastreio'
 publishDate: '2026-02-20'
-lastModified: '2026-02-20'
+lastModified: '2026-04-02'
 primaryKeyword: 'HPV anal'
 secondaryKeywords:
   - 'condilomas anais'
@@ -11,6 +11,8 @@ secondaryKeywords:
   - 'cancer anal HPV'
   - 'vacina HPV adultos'
   - 'coloproctologista Curitiba'
+  - 'verrugas anais curitiba'
+  - 'proctologista curitiba'
 targetAudience: 'patients'
 intent: 'awareness'
 featured: false

--- a/content/posts/tratamento-fistulas-anorretais.md
+++ b/content/posts/tratamento-fistulas-anorretais.md
@@ -3,7 +3,7 @@ title: 'Tratamento de fístulas anorretais'
 metaDescription: 'Entenda sintomas, diagnóstico e opções de tratamento para fístula anal com foco em segurança, preservação da continência e menor recorrência.'
 slug: 'tratamento-fistulas-anorretais'
 publishDate: '2026-03-05'
-lastModified: '2026-03-05'
+lastModified: '2026-04-02'
 primaryKeyword: 'fístula anal'
 secondaryKeywords:
   - 'fístulas anorretais'
@@ -11,6 +11,7 @@ secondaryKeywords:
   - 'seton'
   - 'técnica LIFT'
   - 'coloproctologista Curitiba'
+  - 'proctologista curitiba'
 targetAudience: 'patients'
 intent: 'consideration'
 featured: false

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -18,9 +18,11 @@ const BLOG_PAGE_TITLE = 'Blog — Saúde intestinal sem tabu'
 export const metadata: Metadata = {
   title: BLOG_PAGE_TITLE,
   description:
-    'Orientações práticas sobre hemorroidas, fissuras, intestino preso, HPV anal e mais. Conteúdo direto, sem jargão, escrito por quem trata.',
+    'Orientações práticas de coloproctologia e proctologia sobre hemorroidas, fissuras, intestino preso, HPV anal e mais.',
   keywords: [
     'blog coloproctologia',
+    'blog proctologia',
+    'proctologista curitiba',
     'artigos coloproctologista curitiba',
     'saúde intestinal',
     'tratamento hemorroidas',
@@ -32,7 +34,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: BLOG_PAGE_TITLE,
     description:
-      'Orientações práticas sobre hemorroidas, fissuras, intestino preso, HPV anal e mais. Conteúdo direto, sem jargão, escrito por quem trata.',
+      'Orientações práticas de coloproctologia e proctologia sobre hemorroidas, fissuras, intestino preso, HPV anal e mais.',
     type: 'website',
     locale: 'pt_BR',
     url: `${WEBSITE_URL}/blog`,
@@ -50,7 +52,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: BLOG_PAGE_TITLE,
     description:
-      'Orientações práticas sobre hemorroidas, fissuras, intestino preso, HPV anal e mais. Conteúdo direto, sem jargão, escrito por quem trata.',
+      'Orientações práticas de coloproctologia e proctologia sobre hemorroidas, fissuras, intestino preso, HPV anal e mais.',
     creator: TAG_INSTAGRAM,
     site: TAG_INSTAGRAM,
     images: [`${WEBSITE_URL}/og-image.jpg`],
@@ -81,12 +83,12 @@ export default function BlogPage() {
         <div className="max-w-[1760px] mx-auto px-6 sm:px-8 lg:px-10 xl:px-12">
           <div className="mx-auto max-w-4xl text-center mb-16 lg:mb-20">
             <h1 className="text-3xl sm:text-5xl lg:text-6xl font-serif font-bold text-primary mb-8">
-              Cuidando da sua saúde intestinal
+              Cuidando da sua saúde intestinal com informação clara
             </h1>
             <div className="text-lg md:text-xl lg:text-2xl leading-relaxed text-secondary font-medium">
               <p>
                 Aqui compartilho conhecimentos, dicas práticas e orientações sobre coloproctologia
-                para ajudar você a entender melhor sua saúde intestinal
+                e proctologia para ajudar você a entender melhor sua saúde intestinal
               </p>
             </div>
           </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,7 +37,7 @@ const literata = Literata({
 })
 
 const SITE_BRAND = DR_NAME_ABBREVIATED
-const DEFAULT_SITE_TITLE = `${SITE_BRAND} | Coloproctologista Curitiba`
+const DEFAULT_SITE_TITLE = `${SITE_BRAND} | Coloproctologista e Proctologista Curitiba`
 
 export const metadata: Metadata = {
   metadataBase: new URL(WEBSITE_URL),
@@ -46,14 +46,16 @@ export const metadata: Metadata = {
     template: `%s | ${SITE_BRAND}`,
   },
   description:
-    'Coloproctologista em Curitiba. Cuidado clínico e cirúrgico com foco em hemorroidas, fissuras, fístulas, HPV anal e doenças inflamatórias intestinais. Clínica Nassif, Batel.',
+    'Médica coloproctologista e proctologista em Curitiba. Consultas em coloproctologia no Batel e organização de exames quando indicados, com foco em hemorroidas, fissuras, fístulas, HPV anal e doenças inflamatórias intestinais.',
   keywords: [
     'coloproctologista curitiba',
     'coloproctologia curitiba',
+    'proctologista curitiba',
+    'proctologia curitiba',
     'ana luiza rocha',
     'cirurgia hemorroidas curitiba',
     'tratamento fissura anal',
-    'proctologista curitiba',
+    'médico proctologista curitiba',
     'médica intestino curitiba',
     'cirurgia ânus curitiba',
     'HPV anal tratamento',
@@ -65,8 +67,11 @@ export const metadata: Metadata = {
     'cisto pilonidal cirurgia',
     'fístula anorretal',
     'câncer canal anal',
+    'onde atende dra ana luiza rocha',
     'batel curitiba',
+    'mercês curitiba',
     'clínica nassif',
+    'specta endoscopia digestiva',
     'crm pr 45351',
   ],
   authors: [{ name: DR_NAME }],
@@ -101,7 +106,7 @@ export const metadata: Metadata = {
     url: WEBSITE_URL,
     title: DEFAULT_SITE_TITLE,
     description:
-      'Dra. Ana Luiza M. Rocha, especialista em Coloproctologia em Curitiba. Cuidado clínico e cirúrgico humanizado para tratamento de hemorroidas, fissuras anais, HPV e doenças inflamatórias intestinais.',
+      'Dra. Ana Luiza M. Rocha, médica coloproctologista e proctologista em Curitiba. Consultas em coloproctologia e cuidado humanizado com orientação clara sobre locais de atendimento e exames quando indicados.',
     siteName: `${DR_NAME} - Coloproctologia`,
     images: [
       {
@@ -124,7 +129,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: DEFAULT_SITE_TITLE,
     description:
-      'Especialista em Coloproctologia oferecendo cuidado clínico e cirúrgico humanizado do intestino, reto e ânus em Curitiba.',
+      'Médica coloproctologista e proctologista oferecendo cuidado clínico e cirúrgico humanizado em Curitiba, com informações claras sobre locais de atendimento.',
     images: [
       {
         url: `${WEBSITE_URL}/images/og.png`,

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -40,7 +40,7 @@ import {
 
 const pageTitle = 'Formação e trajetória profissional'
 const pageDescription =
-  'Residência em cirurgia geral, especialização em coloproctologia e fellowship internacional em cirurgia colorretal. Conheça quem cuida de você.'
+  'Residência em cirurgia geral, especialização em coloproctologia, atuação em proctologia e fellowship internacional em cirurgia colorretal. Conheça quem cuida de você.'
 const pageUrl = `${WEBSITE_URL}/sobre`
 
 export const metadata: Metadata = {
@@ -51,7 +51,9 @@ export const metadata: Metadata = {
     'dra ana luiza moraes rocha',
     'crm pr 45351',
     'proctologista curitiba',
+    'proctologia curitiba',
     'medica coloproctologista',
+    'medica proctologista curitiba',
     'cirurgia colorretal curitiba',
   ],
   alternates: {
@@ -258,8 +260,8 @@ export default function SobrePage() {
             </h1>
 
             <h2 className="text-start sm:text-center text-lg md:text-xl lg:text-2xl text-secondary mb-8 leading-relaxed font-medium w-full flex flex-col items-center justify-center max-w-3xl mx-auto">
-              Especialista em Coloproctologia com formação internacional, dedicada ao cuidado
-              integral e humanizado de cada paciente.
+              Médica coloproctologista e proctologista em Curitiba, com formação internacional e
+              dedicada ao cuidado integral e humanizado de cada paciente.
             </h2>
           </div>
 
@@ -272,9 +274,9 @@ export default function SobrePage() {
               forma integral. Durante a graduação em Medicina na <strong>{PUC_PR}</strong>,
               desenvolvi a base sólida da minha formação. Foi durante a&nbsp;
               <strong>residência em Cirurgia Geral, no {HOSPITAL_SANTA_CASA}</strong>, que descobri
-              meu amor pela <strong>coloproctologia</strong> — especialidade que une conhecimento
-              técnico avançado com o cuidado humanizado que sempre busquei oferecer aos meus
-              pacientes.
+              meu amor pela <strong>coloproctologia</strong> e pela atuação em
+              <strong> proctologia</strong> — especialidade que une conhecimento técnico avançado
+              com o cuidado humanizado que sempre busquei oferecer aos meus pacientes.
             </p>
 
             {/* Professional Images Grid */}

--- a/src/app/tratamentos/page.tsx
+++ b/src/app/tratamentos/page.tsx
@@ -8,12 +8,13 @@ import { getTreatmentImageBySlug } from '@/lib/treatment-images'
 export const metadata: Metadata = {
   title: 'Tratamentos em Coloproctologia',
   description:
-    'Do diagnóstico ao pós-operatório: cirurgia a laser, hemorroidas, fístulas, cisto pilonidal, HPV anal e doenças inflamatórias intestinais. Conheça cada abordagem.',
+    'Tratamentos em coloproctologia e proctologia em Curitiba: cirurgia a laser, hemorroidas, fístulas, cisto pilonidal, HPV anal e doenças inflamatórias intestinais.',
   keywords: [
     'coloproctologia curitiba',
+    'proctologia curitiba',
+    'proctologista curitiba',
     'cirurgia hemorroidas curitiba',
     'tratamento fissura anal',
-    'proctologista curitiba',
     'cirurgia laser curitiba',
     'HPV anal curitiba',
     'cisto pilonidal curitiba',
@@ -126,12 +127,12 @@ export default function ServicosPage() {
             </h1>
             <div className="text-lg md:text-xl lg:text-2xl leading-relaxed text-secondary font-medium space-y-4">
               <p>
-                Oferecemos tratamentos especializados com tecnologia avançada e cuidado humanizado
-                para todas as condições coloproctológicas.
+                Oferecemos tratamentos especializados em coloproctologia e proctologia, com
+                tecnologia avançada e cuidado humanizado em Curitiba.
               </p>
               <p>
                 Nossa abordagem é sempre individualizada, buscando o melhor resultado com o menor
-                desconforto possível.
+                desconforto possível no contexto clínico e cirúrgico de cada paciente.
               </p>
             </div>
           </div>
@@ -190,7 +191,7 @@ export default function ServicosPage() {
                   variant="outline"
                   className="text-lg px-8 py-4 font-semibold text-nowrap shadow-lg hover:shadow-xl transform  transition-all duration-300"
                 >
-                  Artigos educativos
+                  Ver artigos
                 </LinkButton>
               </div>
             </div>

--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -34,7 +34,7 @@ export function HeroSection() {
             </h1>
 
             {/* Enhanced Subtitle - Bigger and Better */}
-            <div className="mt-8 mb-12 space-y-4">
+            <div className="mt-8 mb-12">
               <p className="text-2xl lg:text-3xl xl:text-4xl font-serif font-medium text-secondary leading-relaxed lg:max-w-xl">
                 Cuidado Clínico e Cirúrgico do Intestino, Reto e Ânus
               </p>

--- a/src/components/sections/ServicesSection.tsx
+++ b/src/components/sections/ServicesSection.tsx
@@ -83,12 +83,13 @@ export function ServicesSection() {
         {/* Header Section - Enhanced Typography */}
         <div className="mx-auto max-w-4xl text-center mb-16 lg:mb-20 animate-fade-in">
           <h2 className="text-3xl sm:text-5xl lg:text-6xl font-serif font-bold text-primary mb-8">
-            Quando procurar uma coloproctologista?
+            Quando procurar uma coloproctologista ou proctologista?
           </h2>
           <div className="text-lg md:text-xl lg:text-2xl leading-relaxed text-secondary font-medium">
             <p>
-              Reconhecer os sinais e sintomas é fundamental para buscar ajuda no momento adequado.
-              Cada queixa merece atenção especializada e cuidadosa.
+              Reconhecer sinais e sintomas ajuda a buscar atendimento no momento certo. Cada queixa
+              merece avaliação especializada em coloproctologia e proctologia, com investigação
+              cuidadosa e plano individualizado.
             </p>
           </div>
         </div>

--- a/src/components/sections/TreatmentsSection.tsx
+++ b/src/components/sections/TreatmentsSection.tsx
@@ -51,8 +51,8 @@ export function TreatmentsSection() {
           </h2>
           <div className="text-xl lg:text-2xl leading-relaxed text-secondary font-medium space-y-4">
             <p>
-              Nossa consulta é individualizada e detalhada e busca um
-              entendimento completo sobre você e seu problema.
+              Nossa consulta em coloproctologia e proctologia é individualizada, detalhada e busca
+              um entendimento completo sobre você e seu problema.
             </p>
             <p>
               Para nós, cuidar vai além do diagnóstico. Adaptamos cada


### PR DESCRIPTION
## What changed

Adds `proctologista curitiba` and `proctologia curitiba` as first-class keyword targets across the site — the search volume for "proctologista" often exceeds "coloproctologista".

### Sitewide
- `src/app/layout.tsx` — default title template now includes "e Proctologista", meta description updated, keywords list expanded

### Page metadata
- `src/app/blog/page.tsx` — description, OG/Twitter meta, H1 and intro copy
- `src/app/sobre/page.tsx` — pageDescription, keywords, H2 subtitle, body paragraph
- `src/app/tratamentos/page.tsx` — description, keywords, H1 body copy, CTA label "Artigos educativos" → "Ver artigos"

### Section copy
- `HeroSection.tsx` — minor spacing cleanup
- `ServicesSection.tsx` — H2 heading adds "ou proctologista", description updated
- `TreatmentsSection.tsx` — intro copy adds "e proctologia"

### Blog post frontmatter (4 existing posts)
Only `metaDescription`, `secondaryKeywords`, and `lastModified` touched — no body changes:
- `doencas-inflamatorias-intestinais-acompanhamento.md`
- `fissura-anal-toxina-botulinica-tratamento.md`
- `hpv-anal-condilomas-riscos-tratamento-rastreio.md`
- `tratamento-fistulas-anorretais.md`

## Why

"Proctologista" drives significant search volume that the site was not capturing. These changes are copy-only with no structural impact.

## Dependencies

**None.** Fully independent — can be merged before or after any other PR in this series.

## Validation

- `bun run build` passes
- No structural changes — metadata and copy only

---

> Part of the split from analuizamrocha/web#40