### PR TITLE
feat(blog): add related content sections and five new posts

### DIFF
--- a/content/posts/cisto-pilonidal-cisto-sacrococcigeo-mesma-coisa.md
+++ b/content/posts/cisto-pilonidal-cisto-sacrococcigeo-mesma-coisa.md
@@ -1,0 +1,125 @@
+---
+title: 'Cisto pilonidal e cisto sacrococcígeo são a mesma coisa?'
+metaDescription: 'Cisto pilonidal e cisto sacrococcígeo são a mesma coisa? Entenda os termos, sintomas e quando a avaliação cirúrgica é indicada em Curitiba.'
+slug: 'cisto-pilonidal-cisto-sacrococcigeo-mesma-coisa'
+publishDate: '2026-04-02'
+lastModified: '2026-04-02'
+primaryKeyword: 'cisto pilonidal e cisto sacrococcígeo'
+secondaryKeywords:
+  - 'cisto sacrococcigeo curitiba'
+  - 'cisto pilonidal curitiba'
+  - 'cirurgia coccix curitiba'
+  - 'cisto pilonidal cirurgia'
+  - 'proctologista curitiba'
+targetAudience: 'patients'
+intent: 'awareness'
+featured: false
+order: 35
+relatedTreatments:
+  - 'cx-cisto-pilonidal'
+  - 'cx-laser'
+relatedPosts:
+  - 'cisto-pilonidal-cirurgia-laser-quando-operar'
+  - 'cisto-pilonidal-precisa-cirurgia'
+faqs:
+  - question: 'Cisto pilonidal e cisto sacrococcígeo são termos diferentes para o mesmo problema?'
+    answer: 'Na prática, sim. Ambos costumam se referir à mesma condição na região próxima ao cóccix.'
+  - question: 'Todo cisto pilonidal precisa de cirurgia?'
+    answer: 'Nem sempre no mesmo momento, mas casos recorrentes, com inflamação ou drenagem persistente costumam exigir avaliação cirúrgica.'
+  - question: 'Laser pode ser usado em todos os casos?'
+    answer: 'Não. O uso do laser depende da anatomia da lesão, do histórico e do objetivo do tratamento.'
+  - question: 'Abscesso sacrococcígeo é a mesma coisa que cisto pilonidal?'
+    answer: 'O abscesso pode ser uma manifestação inflamada do cisto pilonidal, mas nem todo quadro inflamatório significa o mesmo estágio da doença.'
+---
+
+_Os nomes mudam de um exame para outro, mas a dúvida do paciente costuma ser a mesma: afinal, cisto pilonidal e cisto sacrococcígeo são o mesmo problema?_
+
+Em muitos laudos, buscas no Google ou conversas do dia a dia, aparecem termos como:
+
+- cisto pilonidal,
+- cisto sacrococcígeo,
+- abscesso sacrococcígeo,
+- cisto no cóccix.
+
+Na prática, eles costumam apontar para a mesma região anatômica e para um problema muito semelhante: um processo inflamatório localizado próximo ao sulco interglúteo, na área do cóccix.
+
+## Então os nomes são equivalentes?
+
+Na maior parte dos casos, sim.
+**Cisto pilonidal** é o termo mais usado na rotina médica.
+**Cisto sacrococcígeo** descreve a localização anatômica da lesão.
+
+Dependendo do estágio do quadro, o paciente também pode ouvir expressões como:
+
+- inflamação pilonidal,
+- abscesso pilonidal,
+- doença pilonidal.
+
+O mais importante é entender se existe:
+
+- inflamação ativa,
+- saída de secreção,
+- episódios recorrentes,
+- necessidade de drenagem,
+- indicação de cirurgia definitiva.
+
+## Quais sintomas costumam aparecer?
+
+Os sinais mais comuns incluem:
+
+- dor na região do cóccix,
+- nódulo ou inchaço local,
+- saída de secreção,
+- vermelhidão,
+- episódios repetidos de inflamação.
+
+Em fases mais agudas, pode surgir um **abscesso**, com dor mais intensa e limitação para sentar.
+
+## Quando é só uma inflamação e quando precisa pensar em cirurgia?
+
+Nem todo paciente precisa operar imediatamente.
+Mas alguns cenários merecem atenção:
+
+- crises repetidas,
+- secreção persistente,
+- múltiplos orifícios na linha média,
+- limitação funcional,
+- histórico de drenagem prévia sem resolução definitiva.
+
+Se você quer entender melhor esse momento de decisão, vale complementar com [cisto pilonidal: precisa de cirurgia?](/blog/cisto-pilonidal-precisa-cirurgia).
+
+## O laser entra em quais casos?
+
+O laser pode ser considerado em **casos selecionados**, com avaliação individualizada da anatomia e do histórico.
+Ele não substitui automaticamente outras técnicas, mas pode ser útil quando o objetivo é tratar a doença com menor trauma cirúrgico em contextos adequados.
+
+Para aprofundar esse ponto, a página sobre [cirurgia de cisto pilonidal](/tratamentos/cx-cisto-pilonidal) ajuda a organizar as opções disponíveis.
+Se o interesse é especificamente na abordagem a laser, também vale ver [quando o laser pode ajudar no cisto pilonidal](/tratamentos/cx-laser) e o artigo [cisto pilonidal: quando operar e como o laser pode ajudar](/blog/cisto-pilonidal-cirurgia-laser-quando-operar).
+
+## O que muda quando o quadro fica recorrente?
+
+Quando a inflamação volta várias vezes, o tratamento costuma deixar de ser apenas episódico.
+O objetivo passa a ser:
+
+- reduzir novas crises,
+- diminuir dor e secreção,
+- tratar a doença de forma mais definitiva,
+- orientar cuidados no pós-operatório.
+
+É justamente nessas situações que a avaliação com especialista ajuda a diferenciar medidas temporárias de um plano mais resolutivo.
+
+## Conclusão
+
+Na rotina prática, **cisto pilonidal** e **cisto sacrococcígeo** costumam se referir à mesma condição, localizada na região do cóccix.
+O que realmente muda a conduta não é o nome usado, mas o estágio da doença, a frequência das crises e o impacto na vida do paciente.
+
+Quando há dor recorrente, secreção ou inflamações repetidas, vale procurar avaliação para definir se o caso pede observação, drenagem momentânea ou cirurgia planejada.
+
+---
+
+**Dra. Ana Luiza Moraes Rocha**  
+Médica Coloproctologista  
+CRM-PR 45351 | RQE 36221  
+Especialista em Coloproctologia
+
+> _Este conteúdo tem caráter educativo e não substitui a consulta médica. Procure sempre orientação profissional para diagnóstico e tratamento adequados._

--- a/content/posts/doencas-inflamatorias-intestinais-acompanhamento.md
+++ b/content/posts/doencas-inflamatorias-intestinais-acompanhamento.md
@@ -15,6 +15,11 @@ targetAudience: 'patients'
 intent: 'consideration'
 featured: false
 order: 18
+relatedTreatments:
+  - 'doencas-inflamatorias-intestinais'
+relatedPosts:
+  - 'diarreia-cronica-tratamento'
+  - 'sangue-nas-fezes-quando-procurar-coloproctologista'
 faqs:
   - question: 'Doença de Crohn e Retocolite Ulcerativa têm cura?'
     answer: 'São doenças crônicas. O objetivo é controlar a inflamação, manter remissão e prevenir complicações com acompanhamento regular.'
@@ -33,6 +38,8 @@ As Doenças Inflamatórias Intestinais (DII), como a Doença de Crohn e a Retoco
 Não se trata apenas de controlar sintomas, mas de prevenir complicações, preservar qualidade de vida e reduzir impacto a longo prazo.
 
 A Dra. Ana Luiza, coloproctologista em Curitiba, oferece acompanhamento especializado em Doenças Inflamatórias Intestinais com abordagem integrada e foco em cuidado contínuo.
+
+Se você quiser ver como esse acompanhamento aparece na página de atendimento, vale acessar [Doença de Crohn e retocolite](/tratamentos/doencas-inflamatorias-intestinais).
 
 ![Visão geral das doenças inflamatórias intestinais](/images/posts/doencas-inflamatorias-intestinais-acompanhamento/doencas-inflamatorias-intestinais.webp)
 
@@ -65,6 +72,8 @@ Ambas podem apresentar períodos de atividade e remissão.
 ![Principais manifestações clínicas da Doença de Crohn e da Retocolite Ulcerativa](/images/posts/doencas-inflamatorias-intestinais-acompanhamento/chron-retite-ulcerativa.webp)
 
 O diagnóstico precoce é fundamental para evitar complicações.
+
+Quando diarreia persistente, sangue nas fezes ou perda de peso são os primeiros sinais, estes dois conteúdos podem complementar a leitura: [diarreia crônica: causas, diagnóstico e tratamentos](/blog/diarreia-cronica-tratamento) e [sangue nas fezes: quando se preocupar](/blog/sangue-nas-fezes-quando-procurar-coloproctologista).
 
 ## Avaliação e monitoramento contínuo
 

--- a/content/posts/fissura-anal-toxina-botulinica-tratamento.md
+++ b/content/posts/fissura-anal-toxina-botulinica-tratamento.md
@@ -16,6 +16,12 @@ targetAudience: 'patients'
 intent: 'consideration'
 featured: false
 order: 24
+relatedTreatments:
+  - 'toxina-botulinica'
+  - 'cx-laser'
+relatedPosts:
+  - 'fissura-anal-tratamento'
+  - 'fissura-anal-quando-cirurgia-indicada'
 faqs:
   - question: 'Botox para fissura dói?'
     answer: 'O procedimento costuma ser bem tolerado, mas geralmente realizado com anestésico local.'
@@ -35,6 +41,8 @@ Muitos pacientes perguntam:
 "Botox realmente funciona para fissura?"
 
 A resposta é: em muitos casos, sim.
+
+Quando a dor ao evacuar persiste e a fissura se torna crônica, a avaliação com **proctologista ou coloproctologista** ajuda a definir se o caso ainda responde a medidas clínicas ou se vale considerar opções como a [toxina botulínica para fissura anal](/tratamentos/toxina-botulinica).
 
 ## Como funciona a toxina botulínica?
 
@@ -56,6 +64,8 @@ A aplicação costuma ser considerada quando:
 - o tratamento clínico não foi suficiente
 - existe espasmo muscular importante
 
+Antes de indicar o procedimento, também vale revisar a base do tratamento da fissura, tema explicado em [fissura anal: sintomas, tratamentos e como a coloproctologia pode ajudar](/blog/fissura-anal-tratamento).
+
 ## Vantagens do tratamento
 
 Entre os benefícios estão:
@@ -70,6 +80,8 @@ Entre os benefícios estão:
 Em alguns pacientes, a fissura cicatriza completamente.
 
 Em outros, pode ser necessário repetir o tratamento ou considerar cirurgia.
+
+Quando a resposta não é suficiente ou a fissura já apresenta critérios de cronicidade mais marcados, o próximo passo pode incluir revisão de outras estratégias. Para esse cenário, o artigo [fissura anal: quando a cirurgia está indicada?](/blog/fissura-anal-quando-cirurgia-indicada) complementa bem a leitura.
 
 ## Perguntas frequentes (FAQ)
 

--- a/content/posts/hpv-anal-condilomas-riscos-tratamento-rastreio.md
+++ b/content/posts/hpv-anal-condilomas-riscos-tratamento-rastreio.md
@@ -15,6 +15,12 @@ targetAudience: 'patients'
 intent: 'awareness'
 featured: false
 order: 12
+relatedTreatments:
+  - 'hpv-anal'
+  - 'rastreio-cancer-anal'
+relatedPosts:
+  - 'cancer-canal-anal-rastreio-hpv-quem-deve-se-preocupar'
+  - 'proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento'
 faqs:
   - question: 'HPV anal sempre causa verrugas?'
     answer: 'Não. Muitas infecções são assintomáticas e só são identificadas em exames de rastreio.'
@@ -37,6 +43,8 @@ Essas perguntas são muito comuns no consultório.
 A infecção por **HPV anal** e o aparecimento de **condilomas (verrugas anais)** ainda são cercados de desinformação e estigma. Quando bem acompanhada, porém, é uma condição **tratável, rastreável e prevenível**.
 
 Neste artigo, a **Dra. Ana Luiza**, coloproctologista em Curitiba, explica o que é o HPV anal, sua história natural, os riscos associados, as opções de tratamento, a importância da vacina e do rastreio adequado.
+
+Para ver como esses temas aparecem organizados nas páginas de atendimento, você também pode revisar [tratamento de HPV anal](/tratamentos/hpv-anal) e [rastreio de câncer anal e HPV](/tratamentos/rastreio-cancer-anal).
 
 ![Ilustração de condilomas anais associados ao HPV](/images/posts/hpv-anal/condilomas-hpv.webp)
 
@@ -115,6 +123,8 @@ Semelhante ao exame preventivo ginecológico, avalia alterações celulares.
 Permite visualização detalhada da mucosa anal e identificação de lesões suspeitas, com possibilidade de biópsia.
 
 O rastreio é indicado principalmente para pacientes com fatores de risco, mas deve ser individualizado.
+
+Se a principal dúvida hoje é quem realmente deve investigar e com que urgência, vale complementar esta leitura com [câncer de canal anal: rastreio, HPV e quem deve se preocupar](/blog/cancer-canal-anal-rastreio-hpv-quem-deve-se-preocupar).
 
 ## Tratamento dos condilomas anais
 

--- a/content/posts/ligadura-elastica-hemorroidas-doi-recuperacao.md
+++ b/content/posts/ligadura-elastica-hemorroidas-doi-recuperacao.md
@@ -1,0 +1,136 @@
+---
+title: 'Ligadura elástica para hemorroidas dói? Quando é indicada e como é a recuperação'
+metaDescription: 'Ligadura elástica para hemorroidas dói? Entenda quando é indicada, como funciona e o que esperar da recuperação com proctologista em Curitiba.'
+slug: 'ligadura-elastica-hemorroidas-doi-recuperacao'
+publishDate: '2026-04-02'
+lastModified: '2026-04-02'
+primaryKeyword: 'ligadura elástica para hemorroidas dói'
+secondaryKeywords:
+  - 'ligadura elástica curitiba'
+  - 'ligadura elástica hemorroida'
+  - 'tratamento hemorroidas curitiba'
+  - 'hemorroidas internas'
+  - 'proctologista curitiba'
+targetAudience: 'patients'
+intent: 'consideration'
+featured: false
+order: 33
+relatedTreatments:
+  - 'hemorroidas'
+relatedPosts:
+  - 'hemorroida-sempre-cirurgica-tratamento'
+  - 'thd-hemorroidas-quando-indicado'
+faqs:
+  - question: 'A ligadura elástica dói muito?'
+    answer: 'Ela pode causar pressão ou desconforto leve nos primeiros dias, mas geralmente é bem tolerada quando a indicação é correta.'
+  - question: 'Para quais hemorroidas a ligadura elástica costuma ser indicada?'
+    answer: 'Principalmente para hemorroidas internas de graus II e III em casos selecionados.'
+  - question: 'Precisa de internação?'
+    answer: 'Em geral, não. A ligadura elástica costuma ser feita em ambiente ambulatorial.'
+  - question: 'A hemorroida pode voltar depois?'
+    answer: 'Pode haver recorrência, especialmente se persistirem fatores como constipação, esforço evacuatório e hábitos intestinais inadequados.'
+---
+
+_A ligadura elástica costuma ser lembrada como um tratamento rápido para hemorroidas internas, mas entender a indicação certa faz diferença no conforto e no resultado._
+
+Muitos pacientes chegam à consulta com uma dúvida objetiva:
+"A ligadura elástica dói?"
+
+A resposta mais honesta é que ela pode causar **desconforto**, mas, quando bem indicada, costuma ser um procedimento **rápido, ambulatorial e bem tolerado**.
+
+## O que é a ligadura elástica?
+
+Trata-se de um procedimento usado principalmente para **hemorroidas internas**.
+Uma pequena borracha é posicionada na base do mamilo hemorroidário para interromper o fluxo sanguíneo local.
+
+Com isso:
+
+- o tecido tratado sofre redução progressiva,
+- o sangramento tende a melhorar,
+- e o prolapso pode diminuir.
+
+Se você quer uma visão geral das opções terapêuticas, a página de [tratamento de hemorroidas](/tratamentos/hemorroidas) reúne as principais abordagens usadas na prática.
+
+## Quando a ligadura elástica costuma ser indicada?
+
+Ela costuma ser considerada principalmente em:
+
+- hemorroidas internas de **grau II**,
+- alguns casos de **grau III**,
+- pacientes com sangramento recorrente,
+- quadros em que ainda não há necessidade clara de cirurgia maior.
+
+Em compensação, ela **não é a solução ideal para todo paciente**.
+Hemorroidas externas volumosas, trombose aguda, dor anal importante por outra causa ou combinação de diferentes componentes da doença podem exigir outra estratégia.
+
+## Afinal, dói?
+
+Na maioria das vezes, o que o paciente sente é:
+
+- pressão,
+- desconforto,
+- vontade de evacuar,
+- incômodo nos primeiros dias.
+
+Dor intensa não é o esperado.
+Quando isso acontece, é importante reavaliar, porque pode haver necessidade de ajuste de conduta.
+
+O desconforto costuma ser mais manejável quando:
+
+- a indicação foi correta,
+- o número de áreas tratadas foi adequado,
+- o paciente recebe orientação clara para o pós-procedimento.
+
+## Como costuma ser a recuperação?
+
+Por ser um procedimento ambulatorial, a recuperação tende a ser mais simples do que a de uma cirurgia formal.
+
+Em geral, o paciente é orientado a:
+
+- manter hidratação adequada,
+- evitar esforço evacuatório,
+- usar fibras quando indicado,
+- observar sinais fora do esperado, como dor importante ou sangramento em excesso.
+
+Em muitos casos, o retorno às atividades ocorre de forma relativamente rápida.
+Ainda assim, a evolução depende do grau das hemorroidas, do hábito intestinal e da presença de outras queixas associadas.
+
+## Quando a ligadura elástica pode não ser suficiente?
+
+Existem situações em que a ligadura elástica ajuda, mas não resolve totalmente.
+Isso pode acontecer quando:
+
+- há prolapso mais importante,
+- a doença é mais avançada,
+- coexistem componentes externos significativos,
+- há recidiva frequente.
+
+Nesses cenários, o tratamento pode migrar para outras opções, incluindo cirurgia convencional, cirurgia a laser ou técnicas como THD, dependendo do perfil do caso.
+Se esse é o seu contexto, vale complementar a leitura com [hemorroida é sempre cirúrgica?](/blog/hemorroida-sempre-cirurgica-tratamento) e também com [THD para hemorroidas: quando pode ser indicado](/blog/thd-hemorroidas-quando-indicado).
+
+## O que conversar com o proctologista antes de decidir?
+
+Algumas perguntas úteis são:
+
+- minhas hemorroidas são internas, externas ou mistas?
+- quantas sessões podem ser necessárias?
+- o meu quadro tem melhor perfil para ligadura, cirurgia ou outra técnica?
+- como prevenir recorrência depois do procedimento?
+
+Esse alinhamento evita expectativa irreal e ajuda a escolher a abordagem mais adequada para o seu caso.
+
+## Conclusão
+
+A ligadura elástica pode ser uma ótima opção para **hemorroidas internas selecionadas**, com recuperação relativamente rápida e menor agressividade do que uma cirurgia maior.
+Mas ela funciona melhor quando é indicada com critério e inserida dentro de um plano completo de cuidado intestinal.
+
+Em vez de pensar apenas se o procedimento "dói ou não dói", vale entender se ele realmente é a melhor opção para o tipo de hemorroida presente.
+
+---
+
+**Dra. Ana Luiza Moraes Rocha**  
+Médica Coloproctologista  
+CRM-PR 45351 | RQE 36221  
+Especialista em Coloproctologia
+
+> _Este conteúdo tem caráter educativo e não substitui a consulta médica. Procure sempre orientação profissional para diagnóstico e tratamento adequados._

--- a/content/posts/primeira-consulta-proctologista-curitiba-o-que-esperar.md
+++ b/content/posts/primeira-consulta-proctologista-curitiba-o-que-esperar.md
@@ -1,0 +1,127 @@
+---
+title: 'Primeira consulta com proctologista em Curitiba: o que esperar?'
+metaDescription: 'Saiba como costuma funcionar a primeira consulta com proctologista em Curitiba, o que levar e quando o exame pode ser indicado.'
+slug: 'primeira-consulta-proctologista-curitiba-o-que-esperar'
+publishDate: '2026-04-02'
+lastModified: '2026-04-02'
+primaryKeyword: 'primeira consulta proctologista curitiba'
+secondaryKeywords:
+  - 'consulta com coloproctologista'
+  - 'proctologista curitiba'
+  - 'agendar consulta coloproctologista curitiba'
+  - 'o que levar para consulta proctologista'
+  - 'proctologista e coloproctologista'
+targetAudience: 'patients'
+intent: 'decision'
+featured: false
+order: 36
+relatedTreatments:
+  - 'hemorroidas'
+  - 'sindrome-intestino-irritavel'
+relatedPosts:
+  - 'proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento'
+  - 'quando-procurar-coloproctologista-curitiba'
+faqs:
+  - question: 'Precisa fazer exame já na primeira consulta?'
+    answer: 'Nem sempre. A necessidade de exame depende da queixa, da história clínica e do que for discutido durante a avaliação.'
+  - question: 'O exame com proctologista costuma doer?'
+    answer: 'Muitos exames causam apenas desconforto leve. Quando há dor importante, a conduta precisa ser adaptada ao quadro e ao limite do paciente.'
+  - question: 'O que vale levar para a consulta?'
+    answer: 'Exames prévios, lista de medicamentos, histórico de sintomas e anotações sobre frequência evacuatória, dor ou sangramento ajudam bastante.'
+  - question: 'Posso falar sobre vergonha, medo ou dúvidas mais íntimas?'
+    answer: 'Sim. Esses temas fazem parte da consulta e ajudam a orientar melhor a investigação e o tratamento.'
+---
+
+_A primeira consulta com proctologista não precisa ser cercada de medo: ela começa com escuta, contexto clínico e decisão compartilhada sobre os próximos passos._
+
+Muita gente adia a consulta porque imagina que o atendimento será constrangedor ou que um exame será obrigatório logo no primeiro contato.
+Na prática, a avaliação costuma ser mais organizada, gradual e respeitosa do que o paciente imagina.
+
+Se você está pensando em marcar uma consulta com proctologista em Curitiba, entender como esse encontro costuma acontecer ajuda a chegar mais preparado e menos ansioso.
+
+## O que vale levar para a consulta?
+
+Se tiver disponível, pode ser útil levar:
+
+- exames prévios,
+- receitas e lista de medicações em uso,
+- histórico de cirurgias e doenças,
+- datas aproximadas de início dos sintomas,
+- informações sobre sangramento, dor, constipação ou diarreia.
+
+Esses detalhes ajudam a diferenciar uma queixa episódica de um quadro que já merece investigação mais aprofundada.
+
+## Como a conversa inicial costuma acontecer?
+
+A primeira parte da consulta costuma focar em entender:
+
+- qual é o sintoma principal,
+- quando ele começou,
+- se há piora ao evacuar,
+- se existe sangramento, secreção ou lesões,
+- como funciona o hábito intestinal,
+- quais tratamentos já foram tentados.
+
+Dependendo da história, o raciocínio pode seguir para temas como hemorroidas, fissura anal, sintomas intestinais funcionais, HPV anal ou doenças inflamatórias intestinais.
+
+## O exame é sempre necessário?
+
+Nem sempre.
+Isso depende da queixa, da segurança do paciente e do que a história clínica sugere.
+
+Em alguns casos, a conversa inicial já permite organizar os próximos passos com clareza.
+Em outros, o exame físico ajuda a confirmar hipóteses e direcionar melhor o tratamento.
+
+Quando o exame é indicado, ele deve ser explicado com antecedência e conduzido com respeito ao conforto do paciente.
+
+## Quais queixas costumam aparecer na primeira consulta?
+
+Algumas das mais frequentes são:
+
+- dor ao evacuar,
+- sangramento anal,
+- coceira persistente,
+- sensação de caroço ou lesão,
+- alteração do hábito intestinal,
+- constipação de longa data,
+- diarreia recorrente.
+
+Se a principal suspeita for hemorroida, pode valer revisar a página sobre [tratamento de hemorroidas](/tratamentos/hemorroidas).
+Quando o problema gira em torno de fissura anal crônica e dor intensa, a página de [toxina botulínica para fissura anal](/tratamentos/toxina-botulinica) ajuda a entender uma das opções terapêuticas consideradas em casos selecionados.
+
+## E se eu estiver com vergonha?
+
+Vergonha, medo do exame e receio de julgamento são extremamente comuns.
+Isso não é sinal de exagero.
+Faz parte do contexto de sintomas íntimos e de um tema que ainda carrega muito tabu.
+
+Se esse é o seu caso, vale complementar a leitura com [proctologista e coloproctologista: qual a diferença?](/blog/proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento) e também com [quando procurar um coloproctologista](/blog/quando-procurar-coloproctologista-curitiba).
+
+## Quando a consulta deve ser antecipada?
+
+Em vez de esperar meses, vale procurar atendimento mais cedo quando houver:
+
+- sangue nas fezes,
+- dor anal intensa,
+- secreção persistente,
+- perda de peso inexplicada,
+- diarreia crônica,
+- sintomas que não melhoram com medidas simples.
+
+Quanto mais claro estiver o quadro, mais cedo é possível definir investigação, tratamento e acompanhamento.
+
+## Conclusão
+
+A primeira consulta com proctologista costuma ser um momento de escuta, organização do raciocínio clínico e esclarecimento de dúvidas.
+Nem todo paciente precisa fazer exame imediatamente, e a avaliação deve sempre ser conduzida com cuidado e respeito.
+
+Chegar preparado ajuda, mas o principal é não adiar sinais que já estão interferindo na sua rotina ou trazendo preocupação.
+
+---
+
+**Dra. Ana Luiza Moraes Rocha**  
+Médica Coloproctologista  
+CRM-PR 45351 | RQE 36221  
+Especialista em Coloproctologia
+
+> _Este conteúdo tem caráter educativo e não substitui a consulta médica. Procure sempre orientação profissional para diagnóstico e tratamento adequados._

--- a/content/posts/proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento.md
+++ b/content/posts/proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento.md
@@ -1,0 +1,130 @@
+---
+title: 'Proctologista e coloproctologista: qual a diferença e quando procurar atendimento?'
+metaDescription: 'Entenda a diferença entre proctologista e coloproctologista, quais sintomas merecem avaliação e quando marcar consulta em Curitiba.'
+slug: 'proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento'
+publishDate: '2026-04-02'
+lastModified: '2026-04-02'
+primaryKeyword: 'proctologista e coloproctologista'
+secondaryKeywords:
+  - 'proctologista curitiba'
+  - 'coloproctologista curitiba'
+  - 'proctologia'
+  - 'quando procurar proctologista'
+  - 'consulta com coloproctologista'
+targetAudience: 'patients'
+intent: 'awareness'
+featured: false
+order: 32
+relatedTreatments:
+  - 'hemorroidas'
+  - 'sindrome-intestino-irritavel'
+relatedPosts:
+  - 'quando-procurar-coloproctologista-curitiba'
+  - 'primeira-consulta-proctologista-curitiba-o-que-esperar'
+faqs:
+  - question: 'Proctologista e coloproctologista são a mesma coisa?'
+    answer: 'Na prática, os dois termos costumam ser usados para a mesma área. Coloproctologia é o nome mais preciso da especialidade médica.'
+  - question: 'Quando devo procurar um proctologista?'
+    answer: 'Quando há sintomas como sangramento anal, dor ao evacuar, coceira persistente, alteração do hábito intestinal, lesões anais ou desconforto intestinal recorrente.'
+  - question: 'O proctologista trata apenas doenças do ânus?'
+    answer: 'Não. A coloproctologia também acompanha condições do reto, cólon e intestino, como constipação, diarreia crônica, síndrome do intestino irritável e doenças inflamatórias intestinais.'
+  - question: 'Toda consulta com proctologista inclui exame?'
+    answer: 'Nem sempre. A necessidade de exame físico depende da queixa, do contexto clínico e da conversa com o paciente durante a avaliação.'
+---
+
+_Os termos “proctologista” e “coloproctologista” costumam gerar dúvida, mas o mais importante é reconhecer os sintomas e procurar avaliação no momento certo._
+
+Quem procura no Google por **proctologista** muitas vezes encontra também o termo **coloproctologista**.
+Isso pode passar a impressão de que se tratam de profissionais diferentes, quando, na prática, o foco é o mesmo: avaliar doenças do intestino, reto e ânus com critério técnico e cuidado individualizado.
+
+Se você tem sintomas como dor anal, sangramento, alteração do hábito intestinal ou lesões na região anal, vale entender como essa especialidade atua e quando faz sentido marcar consulta.
+
+## Proctologista e coloproctologista: existe diferença?
+
+Hoje, o termo **coloproctologista** é o mais preciso para descrever a especialidade.
+Ele reflete o cuidado com:
+
+- ânus e canal anal,
+- reto,
+- cólon,
+- e parte das queixas intestinais que exigem avaliação especializada.
+
+Já o termo **proctologista** continua muito usado no dia a dia e nas buscas dos pacientes.
+Por isso, quando alguém procura um proctologista em Curitiba, geralmente está buscando o mesmo tipo de atendimento oferecido pela coloproctologia.
+
+## Quais sintomas costumam levar o paciente ao consultório?
+
+Alguns exemplos frequentes são:
+
+- sangramento ao evacuar,
+- dor anal ou dor ao evacuar,
+- coceira anal persistente,
+- saída de secreção na região anal,
+- alteração do hábito intestinal,
+- constipação de longa data,
+- diarreia recorrente,
+- sensação de evacuação incompleta,
+- verrugas, nódulos ou lesões anais.
+
+Dependendo da queixa, a investigação pode seguir caminhos diferentes.
+Em casos de **hemorroidas**, por exemplo, pode fazer sentido revisar a página sobre [tratamento de hemorroidas](/tratamentos/hemorroidas).
+Quando o problema principal é **dor intensa com fissura anal**, pode ser útil entender opções como a [toxina botulínica para fissura anal](/tratamentos/toxina-botulinica).
+
+## O que um proctologista também acompanha além das doenças anais?
+
+A especialidade não se restringe às doenças orificiais.
+Ela também pode participar da avaliação e do acompanhamento de quadros como:
+
+- **síndrome do intestino irritável**,
+- constipação intestinal crônica,
+- diarreia persistente,
+- **Doença de Crohn e retocolite ulcerativa**,
+- rastreio de lesões associadas ao HPV e câncer anal,
+- necessidade de integração com colonoscopia e outros exames.
+
+Se a queixa principal é dor abdominal, distensão, constipação ou alternância do ritmo intestinal, a página sobre [síndrome do intestino irritável](/tratamentos/sindrome-intestino-irritavel) pode ajudar a entender quando a investigação especializada é indicada.
+
+## Quando vale marcar consulta sem adiar?
+
+Algumas situações merecem atenção mais precoce:
+
+- sangue nas fezes, mesmo em pequena quantidade,
+- dor anal forte e persistente,
+- recorrência de abscessos ou secreção anal,
+- emagrecimento sem causa aparente,
+- diarreia crônica,
+- lesões anais novas,
+- história pessoal de doença inflamatória intestinal,
+- sintomas intestinais que não melhoram com medidas simples.
+
+Se você quiser uma visão mais ampla sobre sinais de alerta, este conteúdo complementa a leitura: [quando procurar um coloproctologista](/blog/quando-procurar-coloproctologista-curitiba).
+
+## E a primeira consulta, como costuma funcionar?
+
+A avaliação começa pela história clínica.
+O objetivo é entender:
+
+- como os sintomas começaram,
+- o que piora ou melhora,
+- se há sangramento, dor, secreção ou alteração intestinal,
+- histórico de cirurgias, exames e tratamentos prévios,
+- condições clínicas associadas.
+
+Dependendo do caso, o exame físico pode ser indicado, mas isso é sempre contextualizado e conversado com o paciente.
+Se você quer se preparar melhor para esse momento, vale seguir para o artigo [primeira consulta com proctologista em Curitiba: o que esperar](/blog/primeira-consulta-proctologista-curitiba-o-que-esperar).
+
+## Conclusão
+
+Na prática, **proctologista** e **coloproctologista** costumam apontar para o mesmo cuidado especializado.
+Mais importante do que o nome usado na busca é reconhecer sintomas que merecem avaliação e procurar atendimento antes que o quadro se torne mais arrastado ou complexo.
+
+Quando há sinais anais ou intestinais persistentes, a consulta permite organizar a investigação, esclarecer medos e definir com mais segurança o próximo passo.
+
+---
+
+**Dra. Ana Luiza Moraes Rocha**  
+Médica Coloproctologista  
+CRM-PR 45351 | RQE 36221  
+Especialista em Coloproctologia
+
+> _Este conteúdo tem caráter educativo e não substitui a consulta médica. Procure sempre orientação profissional para diagnóstico e tratamento adequados._

--- a/content/posts/thd-hemorroidas-quando-indicado.md
+++ b/content/posts/thd-hemorroidas-quando-indicado.md
@@ -1,0 +1,125 @@
+---
+title: 'THD para hemorroidas: quando pode ser indicado?'
+metaDescription: 'THD para hemorroidas: saiba quando essa técnica pode ser indicada, quais são as vantagens e limites e o que avaliar com coloproctologista em Curitiba.'
+slug: 'thd-hemorroidas-quando-indicado'
+publishDate: '2026-04-02'
+lastModified: '2026-04-02'
+primaryKeyword: 'THD para hemorroidas'
+secondaryKeywords:
+  - 'THD curitiba'
+  - 'cirurgia hemorroidas curitiba'
+  - 'desarterialização hemorroidária'
+  - 'hemorroidas internas'
+  - 'proctologista curitiba'
+targetAudience: 'patients'
+intent: 'consideration'
+featured: false
+order: 34
+relatedTreatments:
+  - 'hemorroidas'
+relatedPosts:
+  - 'ligadura-elastica-hemorroidas-doi-recuperacao'
+  - 'hemorroida-sempre-cirurgica-tratamento'
+faqs:
+  - question: 'O que significa THD?'
+    answer: 'THD é a sigla para desarterialização hemorroidária transanal, técnica que identifica e reduz o fluxo das artérias hemorroidárias.'
+  - question: 'THD é indicado para qualquer hemorroida?'
+    answer: 'Não. A indicação depende do grau da doença, do tipo de prolapso e das características do paciente.'
+  - question: 'A recuperação costuma ser melhor do que na cirurgia convencional?'
+    answer: 'Em muitos casos, a dor no pós-operatório pode ser menor, mas a recuperação varia conforme a extensão da doença e a técnica escolhida.'
+  - question: 'O resultado é definitivo?'
+    answer: 'Nenhuma técnica elimina totalmente o risco de recorrência. O controle dos hábitos intestinais continua sendo importante.'
+---
+
+_THD é uma das técnicas menos comentadas fora do consultório, mas pode ser uma opção interessante para casos selecionados de hemorroidas internas._
+
+Quando o paciente descobre que existem diferentes tipos de procedimento para hemorroida, é comum aparecer uma nova dúvida:
+"THD pode ser melhor do que operar da forma tradicional?"
+
+A resposta depende menos do nome da técnica e mais do **tipo de hemorroida**, do **grau de prolapso** e do objetivo do tratamento.
+
+## O que é THD?
+
+THD é a sigla para **Transanal Hemorrhoidal Dearterialization**, também chamada de **desarterialização hemorroidária transanal**.
+
+De forma simplificada, a técnica busca:
+
+- identificar as artérias hemorroidárias com auxílio de doppler,
+- reduzir o fluxo sanguíneo para os mamilos hemorroidários,
+- e, em alguns casos, associar correção do prolapso da mucosa.
+
+Ela costuma ser considerada uma abordagem **minimamente invasiva** dentro do arsenal cirúrgico para hemorroidas.
+
+## Em quais situações pode ser indicada?
+
+O THD pode fazer sentido principalmente em:
+
+- hemorroidas internas de **grau II e III**,
+- pacientes com prolapso moderado,
+- casos em que se busca menor trauma tecidual,
+- cenários selecionados em que a anatomia favorece essa estratégia.
+
+Isso não significa que toda hemorroida interna seja tratada dessa maneira.
+Por isso, a avaliação clínica segue sendo essencial.
+
+Para entender o panorama geral das opções, vale revisar a página de [tratamento de hemorroidas](/tratamentos/hemorroidas).
+
+## Quais são as possíveis vantagens?
+
+Entre os motivos que levam essa técnica a ser considerada estão:
+
+- menor trauma em comparação com algumas cirurgias excisionais,
+- possibilidade de pós-operatório mais confortável em casos selecionados,
+- preservação anatômica maior de tecidos externos.
+
+Ainda assim, benefício potencial não é sinônimo de indicação automática.
+
+## Quais são os limites do THD?
+
+Alguns pontos importantes:
+
+- nem toda hemorroida tem perfil anatômico adequado para THD,
+- a presença de componente externo volumoso pode reduzir a utilidade da técnica,
+- existe possibilidade de recorrência,
+- a escolha depende da experiência do especialista e da disponibilidade do método.
+
+Ou seja: THD é uma ferramenta, não uma solução universal.
+
+## THD, ligadura elástica ou cirurgia convencional?
+
+Essa comparação costuma gerar expectativa, mas a melhor pergunta é outra:
+"Qual técnica combina melhor com o meu caso?"
+
+Em alguns pacientes, a **ligadura elástica** pode resolver bem, com tratamento ambulatorial e recuperação rápida.
+Em outros, a doença já pede abordagem cirúrgica mais estruturada.
+Se você ainda está nessa etapa de decisão, o artigo [ligadura elástica para hemorroidas dói?](/blog/ligadura-elastica-hemorroidas-doi-recuperacao) ajuda a comparar contextos.
+
+Já para quem quer entender quando a cirurgia entra na conversa, este conteúdo complementa bem a análise: [hemorroida é sempre cirúrgica?](/blog/hemorroida-sempre-cirurgica-tratamento).
+
+## Como costuma ser a recuperação?
+
+Em muitos casos, a recuperação tende a ser mais confortável do que em técnicas excisionais clássicas.
+Mesmo assim, o pós-operatório pode incluir:
+
+- desconforto ao evacuar,
+- sensação de peso,
+- necessidade de ajuste do ritmo intestinal,
+- acompanhamento para monitorar resposta e cicatrização.
+
+O resultado depende não só da técnica, mas também do controle de fatores como constipação, esforço evacuatório e qualidade das evacuações.
+
+## Conclusão
+
+O THD pode ser uma alternativa útil para **hemorroidas internas selecionadas**, especialmente quando o objetivo é combinar eficácia com menor agressão tecidual.
+Mas a decisão deve ser feita de forma individualizada, comparando essa técnica com outras opções realmente adequadas ao quadro clínico.
+
+No tratamento das hemorroidas, a melhor técnica não é a mais moderna no papel, e sim a que faz mais sentido para o problema que está sendo tratado.
+
+---
+
+**Dra. Ana Luiza Moraes Rocha**  
+Médica Coloproctologista  
+CRM-PR 45351 | RQE 36221  
+Especialista em Coloproctologia
+
+> _Este conteúdo tem caráter educativo e não substitui a consulta médica. Procure sempre orientação profissional para diagnóstico e tratamento adequados._

--- a/content/posts/tratamento-fistulas-anorretais.md
+++ b/content/posts/tratamento-fistulas-anorretais.md
@@ -15,6 +15,11 @@ targetAudience: 'patients'
 intent: 'consideration'
 featured: false
 order: 17
+relatedTreatments:
+  - 'cx-fistulas-anorretais'
+relatedPosts:
+  - 'doencas-inflamatorias-intestinais-acompanhamento'
+  - 'proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento'
 faqs:
   - question: 'Fístula anal melhora sozinha?'
     answer: 'Na maioria dos casos, não. Sem tratamento adequado, o trajeto fistuloso tende a persistir e recidivar.'
@@ -34,6 +39,8 @@ Quando mal conduzida, pode gerar recorrência, inflamações repetidas e, princi
 O diferencial no tratamento da fístula está em compreender que **cada trajeto fistuloso é único** e que a decisão terapêutica deve equilibrar eficácia e preservação da função.
 
 A Dra. Ana Luiza, coloproctologista em Curitiba, realiza diagnóstico detalhado e oferece abordagem individualizada para o tratamento de fístulas anorretais, com foco em segurança, preservação esfincteriana e acompanhamento próximo.
+
+Se você quiser comparar as técnicas descritas aqui com a organização da página de atendimento, vale revisar também [cirurgias para fístulas anorretais](/tratamentos/cx-fistulas-anorretais).
 
 ![Ilustração de fístula anorretal e trajeto fistuloso](/images/posts/tratamento-fistulas-anorretais/fistula.webp)
 
@@ -136,6 +143,8 @@ Procure avaliação especializada se você apresenta:
 - Doença de Crohn com sintomas anais.
 
 O tratamento precoce reduz complicações e melhora os resultados funcionais.
+
+Quando existe associação com sintomas intestinais mais amplos ou suspeita de inflamação de base, este conteúdo pode ajudar a complementar o raciocínio: [Doenças inflamatórias intestinais (DII): acompanhamento especializado](/blog/doencas-inflamatorias-intestinais-acompanhamento).
 
 ---
 

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -6,6 +6,7 @@ import remarkGfm from 'remark-gfm'
 import { CallToActionCard } from '@/components/ui/CallToActionCard'
 import {
   getPostBySlug,
+  getAllPosts,
   getAllPostSlugs,
   generateBlogPostSchema,
   getTargetAudienceLabel,
@@ -21,6 +22,12 @@ import {
 } from '@/lib/constants'
 import { LinkButton } from '@/components/ui/LinkButton'
 import { MdxImage } from '@/components/ui/MdxImage'
+import { RelatedTreatmentsSection } from '@/components/ui/RelatedTreatmentsSection'
+import { RelatedPostsSection } from '@/components/ui/RelatedPostsSection'
+import {
+  getResolvedRelatedPostSlugs,
+  getResolvedRelatedTreatmentSlugs,
+} from '@/lib/content-relationships'
 
 interface BlogPostPageProps {
   params: Promise<{
@@ -104,12 +111,18 @@ export async function generateMetadata({ params }: BlogPostPageProps): Promise<M
 export default async function BlogPostPage({ params }: BlogPostPageProps) {
   const { slug } = await params
   const post = getPostBySlug(slug)
+  const allPosts = getAllPosts()
 
   if (!post) {
     notFound()
   }
 
   const schema = generateBlogPostSchema(post)
+  const relatedTreatmentSlugs = getResolvedRelatedTreatmentSlugs(post)
+  const relatedPostSlugs = getResolvedRelatedPostSlugs(post, allPosts)
+  const relatedPosts = relatedPostSlugs
+    .map((relatedSlug) => allPosts.find((candidate) => candidate.slug === relatedSlug))
+    .filter((candidate): candidate is NonNullable<typeof candidate> => Boolean(candidate))
 
   return (
     <>
@@ -206,6 +219,9 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
                 components={{ img: MdxImage }}
               />
             </div>
+
+            <RelatedTreatmentsSection treatmentSlugs={relatedTreatmentSlugs} />
+            <RelatedPostsSection posts={relatedPosts} />
           </div>
 
           {/* Article Footer */}

--- a/src/components/ui/RelatedBlogCard.tsx
+++ b/src/components/ui/RelatedBlogCard.tsx
@@ -1,15 +1,21 @@
 import { Badge } from '@/components/ui/Badge'
 import { LinkButton } from '@/components/ui/LinkButton'
-import { getRelatedBlogByTreatmentSlug } from '@/lib/treatment-related-blog'
+import { getAllPosts } from '@/lib/blog'
+import { getRelatedPostsForTreatment } from '@/lib/content-relationships'
+import type { TreatmentSlug } from '@/lib/treatment-images'
 
 interface RelatedBlogCardProps {
   treatmentSlug: string
 }
 
 export function RelatedBlogCard({ treatmentSlug }: RelatedBlogCardProps) {
-  const relatedBlog = getRelatedBlogByTreatmentSlug(treatmentSlug)
+  const relatedPosts = getRelatedPostsForTreatment(
+    treatmentSlug as TreatmentSlug,
+    getAllPosts(),
+    4
+  )
 
-  if (!relatedBlog) {
+  if (relatedPosts.length === 0) {
     return null
   }
 
@@ -19,17 +25,24 @@ export function RelatedBlogCard({ treatmentSlug }: RelatedBlogCardProps) {
         <Badge variant="secondary" className="mb-4">
           Leitura relacionada
         </Badge>
-        <h3 className="text-xl sm:text-2xl font-serif font-bold text-primary mb-3 leading-tight">
-          {relatedBlog.title}
-        </h3>
-        <p className="text-base text-secondary leading-relaxed mb-6">{relatedBlog.description}</p>
-        <LinkButton
-          href={relatedBlog.href}
-          variant="outline"
-          size="default"
-        >
-          Ver artigo no blog
-        </LinkButton>
+        <div className="grid gap-4 md:grid-cols-2">
+          {relatedPosts.map((post) => (
+            <article
+              key={post.slug}
+              className="flex flex-col rounded-2xl border border-secondary/15 bg-background/80 p-5"
+            >
+              <h3 className="text-lg sm:text-xl font-serif font-bold text-primary mb-3 leading-tight">
+                {post.title}
+              </h3>
+              <p className="flex-1 text-sm sm:text-base text-secondary leading-relaxed mb-5">
+                {post.excerpt}
+              </p>
+              <LinkButton href={`/blog/${post.slug}`} variant="outline" size="default">
+                Ver artigo no blog
+              </LinkButton>
+            </article>
+          ))}
+        </div>
       </div>
     </aside>
   )

--- a/src/components/ui/RelatedPostsSection.tsx
+++ b/src/components/ui/RelatedPostsSection.tsx
@@ -1,0 +1,36 @@
+import { Badge } from '@/components/ui/Badge'
+import { TreatmentCard } from '@/components/ui/TreatmentCard'
+import type { BlogPost } from '@/lib/blog'
+
+interface RelatedPostsSectionProps {
+  posts: BlogPost[]
+}
+
+export function RelatedPostsSection({ posts }: RelatedPostsSectionProps) {
+  const relatedPosts = posts.slice(0, 2)
+
+  if (relatedPosts.length === 0) {
+    return null
+  }
+
+  return (
+    <aside className="not-prose my-10">
+      <div className="rounded-3xl border border-secondary/20 bg-primary/5 p-6 sm:p-8">
+        <Badge variant="primary" className="mb-4">
+          Continue lendo
+        </Badge>
+        <div className="grid gap-4 md:grid-cols-2">
+          {relatedPosts.map((post) => (
+            <TreatmentCard
+              key={post.slug}
+              href={`/blog/${post.slug}`}
+              title={post.title}
+              description={post.excerpt}
+              variant="detailed"
+            />
+          ))}
+        </div>
+      </div>
+    </aside>
+  )
+}

--- a/src/components/ui/RelatedTreatmentsSection.tsx
+++ b/src/components/ui/RelatedTreatmentsSection.tsx
@@ -1,0 +1,39 @@
+import { Badge } from '@/components/ui/Badge'
+import { TreatmentCard } from '@/components/ui/TreatmentCard'
+import { getTreatmentLinkBySlug } from '@/lib/content-relationships'
+
+interface RelatedTreatmentsSectionProps {
+  treatmentSlugs: string[]
+}
+
+export function RelatedTreatmentsSection({ treatmentSlugs }: RelatedTreatmentsSectionProps) {
+  const relatedTreatments = treatmentSlugs
+    .map((slug) => getTreatmentLinkBySlug(slug))
+    .filter((treatment): treatment is NonNullable<typeof treatment> => Boolean(treatment))
+    .slice(0, 2)
+
+  if (relatedTreatments.length === 0) {
+    return null
+  }
+
+  return (
+    <aside className="not-prose my-10">
+      <div className="rounded-3xl border border-secondary/20 bg-secondary/10 p-6 sm:p-8">
+        <Badge variant="secondary" className="mb-4">
+          Tratamentos relacionados
+        </Badge>
+        <div className="grid gap-4 md:grid-cols-2">
+          {relatedTreatments.map((treatment) => (
+            <TreatmentCard
+              key={treatment.slug}
+              href={treatment.href}
+              title={treatment.title}
+              description={treatment.description}
+              variant="detailed"
+            />
+          ))}
+        </div>
+      </div>
+    </aside>
+  )
+}

--- a/src/lib/content-relationships.ts
+++ b/src/lib/content-relationships.ts
@@ -1,0 +1,265 @@
+import type { BlogPost } from '@/lib/blog'
+import type { TreatmentSlug } from '@/lib/treatment-images'
+
+export interface TreatmentLinkEntry {
+  slug: TreatmentSlug
+  href: string
+  title: string
+  description: string
+}
+
+const buildRelationshipMap = (slugs: string[], relatedTreatments: TreatmentSlug[]) =>
+  Object.fromEntries(slugs.map((slug) => [slug, relatedTreatments]))
+
+export const TREATMENT_LINK_BY_SLUG: Record<TreatmentSlug, TreatmentLinkEntry> = {
+  'cx-laser': {
+    slug: 'cx-laser',
+    href: '/tratamentos/cx-laser',
+    title: 'Cirurgia a laser proctológica',
+    description:
+      'Veja quando o laser pode ser considerado em hemorroidas, fissuras e outras doenças orificiais.',
+  },
+  hemorroidas: {
+    slug: 'hemorroidas',
+    href: '/tratamentos/hemorroidas',
+    title: 'Tratamento de hemorroidas',
+    description:
+      'Entenda opções como ligadura elástica, escleroterapia, hemorroidectomia, laser e THD.',
+  },
+  'cx-fistulas-anorretais': {
+    slug: 'cx-fistulas-anorretais',
+    href: '/tratamentos/cx-fistulas-anorretais',
+    title: 'Cirurgias para fístulas anorretais',
+    description:
+      'Compare fistulotomia, seton, LIFT, retalho mucoso e técnicas combinadas para fístula anal.',
+  },
+  'toxina-botulinica': {
+    slug: 'toxina-botulinica',
+    href: '/tratamentos/toxina-botulinica',
+    title: 'Toxina botulínica para fissura anal',
+    description:
+      'Saiba quando o botox anal pode ser considerado para fissura anal crônica e dor anal persistente.',
+  },
+  'rastreio-cancer-anal': {
+    slug: 'rastreio-cancer-anal',
+    href: '/tratamentos/rastreio-cancer-anal',
+    title: 'Rastreio de câncer anal e HPV',
+    description:
+      'Conheça citologia anal, anuscopia de alta resolução e critérios de rastreio em grupos de risco.',
+  },
+  'hpv-anal': {
+    slug: 'hpv-anal',
+    href: '/tratamentos/hpv-anal',
+    title: 'Tratamento de HPV anal',
+    description:
+      'Veja como é feita a avaliação, o tratamento de condilomas e o acompanhamento das lesões por HPV.',
+  },
+  'cx-cisto-pilonidal': {
+    slug: 'cx-cisto-pilonidal',
+    href: '/tratamentos/cx-cisto-pilonidal',
+    title: 'Cirurgia de cisto pilonidal',
+    description:
+      'Entenda quando operar, como avaliar recorrência e em quais casos o laser pode ajudar.',
+  },
+  'doencas-inflamatorias-intestinais': {
+    slug: 'doencas-inflamatorias-intestinais',
+    href: '/tratamentos/doencas-inflamatorias-intestinais',
+    title: 'Doença de Crohn e retocolite',
+    description:
+      'Acompanhamento especializado para doenças inflamatórias intestinais, remissão e prevenção de complicações.',
+  },
+  'sindrome-intestino-irritavel': {
+    slug: 'sindrome-intestino-irritavel',
+    href: '/tratamentos/sindrome-intestino-irritavel',
+    title: 'Síndrome do intestino irritável',
+    description:
+      'Investigação e acompanhamento de dor abdominal, distensão, constipação e diarreia funcionais.',
+  },
+}
+
+const DEFAULT_RELATED_TREATMENTS_BY_POST_SLUG: Record<string, TreatmentSlug[]> = {
+  ...buildRelationshipMap(
+    [
+      'hemorroida-sempre-cirurgica-tratamento',
+      'hemorroida-sempre-precisa-cirurgia',
+      'hemorroida-quanto-tempo-dura-quando-procurar',
+      'sangue-papel-higienico-sempre-hemorroida',
+      'ligadura-elastica-hemorroidas-doi-recuperacao',
+      'thd-hemorroidas-quando-indicado',
+    ],
+    ['hemorroidas']
+  ),
+  ...buildRelationshipMap(
+    [
+      'fissura-anal-tratamento',
+      'fissura-anal-toxina-botulinica-tratamento',
+      'fissura-anal-quando-cirurgia-indicada',
+      'dor-ao-evacuar-causas-tratamento',
+      'proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento',
+      'primeira-consulta-proctologista-curitiba-o-que-esperar',
+    ],
+    ['toxina-botulinica', 'cx-laser']
+  ),
+  ...buildRelationshipMap(
+    [
+      'tratamento-fistulas-anorretais',
+      'proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento',
+    ],
+    ['cx-fistulas-anorretais']
+  ),
+  ...buildRelationshipMap(
+    [
+      'hpv-anal-condilomas-riscos-tratamento-rastreio',
+      'cancer-canal-anal-rastreio-hpv-quem-deve-se-preocupar',
+      'saude-sexual-cuidado-informacao-bem-estar',
+      'coceira-anal-quando-procurar-coloproctologista-curitiba',
+      'coceira-anus-causas-tratamento',
+      'proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento',
+    ],
+    ['hpv-anal', 'rastreio-cancer-anal']
+  ),
+  ...buildRelationshipMap(
+    [
+      'cisto-pilonidal-cirurgia-laser-quando-operar',
+      'cisto-pilonidal-precisa-cirurgia',
+      'cisto-pilonidal-cisto-sacrococcigeo-mesma-coisa',
+    ],
+    ['cx-cisto-pilonidal', 'cx-laser']
+  ),
+  ...buildRelationshipMap(
+    [
+      'constipacao-intestinal-cronica-causas-tratamento',
+      'diarreia-cronica-tratamento',
+      'sindrome-intestino-irritavel-sintomas-diagnostico-tratamento',
+      'alimentacao-e-saude-intestinal',
+      'alimentacao-fibras-saude-intestinal',
+      'disbiose-sibo-tratamento',
+      'disturbios-assoalho-pelvico-funcionamento-intestino',
+      'intestino-preso-muitos-dias-perigoso',
+      'por-que-meus-sintomas-nunca-melhoram',
+      'proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento',
+      'primeira-consulta-proctologista-curitiba-o-que-esperar',
+    ],
+    ['sindrome-intestino-irritavel']
+  ),
+  ...buildRelationshipMap(
+    [
+      'doencas-inflamatorias-intestinais-acompanhamento',
+      'diarreia-cronica-tratamento',
+      'sangue-nas-fezes-quando-procurar-coloproctologista',
+      'quando-intestino-da-sinais-de-alerta-coloproctologista-curitiba',
+      'cancer-colorretal-rastreio-prevencao-diagnostico-precoce',
+      'por-que-meus-sintomas-nunca-melhoram',
+      'primeira-consulta-proctologista-curitiba-o-que-esperar',
+    ],
+    ['doencas-inflamatorias-intestinais']
+  ),
+  'plicoma-anal-cirurgia-laser': ['cx-laser'],
+  'plicoma-anal-vale-a-pena-retirar': ['cx-laser'],
+  'quando-procurar-coloproctologista-curitiba': ['hemorroidas', 'sindrome-intestino-irritavel'],
+  'quando-intestino-da-sinais-de-alerta-coloproctologista-curitiba': [
+    'hemorroidas',
+    'doencas-inflamatorias-intestinais',
+  ],
+  'sangue-nas-fezes-quando-procurar-coloproctologista': [
+    'hemorroidas',
+    'doencas-inflamatorias-intestinais',
+  ],
+  'sinto-vergonha-procurar-coloproctologista-isso-e-normal': [
+    'hemorroidas',
+    'sindrome-intestino-irritavel',
+  ],
+  'o-que-muda-acompanhamento-especializado-coloproctologista-curitiba': [
+    'doencas-inflamatorias-intestinais',
+    'sindrome-intestino-irritavel',
+  ],
+}
+
+const DEFAULT_RELATED_POSTS_BY_POST_SLUG: Record<string, string[]> = {
+  'proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento': [
+    'quando-procurar-coloproctologista-curitiba',
+    'primeira-consulta-proctologista-curitiba-o-que-esperar',
+  ],
+  'primeira-consulta-proctologista-curitiba-o-que-esperar': [
+    'proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento',
+    'quando-procurar-coloproctologista-curitiba',
+  ],
+  'ligadura-elastica-hemorroidas-doi-recuperacao': [
+    'hemorroida-sempre-cirurgica-tratamento',
+    'thd-hemorroidas-quando-indicado',
+  ],
+  'thd-hemorroidas-quando-indicado': [
+    'ligadura-elastica-hemorroidas-doi-recuperacao',
+    'hemorroida-sempre-cirurgica-tratamento',
+  ],
+  'cisto-pilonidal-cisto-sacrococcigeo-mesma-coisa': [
+    'cisto-pilonidal-cirurgia-laser-quando-operar',
+    'cisto-pilonidal-precisa-cirurgia',
+  ],
+}
+
+const unique = <T,>(values: T[]) => Array.from(new Set(values))
+
+export function getTreatmentLinkBySlug(slug: string): TreatmentLinkEntry | undefined {
+  return TREATMENT_LINK_BY_SLUG[slug as TreatmentSlug]
+}
+
+export function getResolvedRelatedTreatmentSlugs(
+  post: Pick<BlogPost, 'slug' | 'relatedTreatments'>
+): TreatmentSlug[] {
+  if (post.relatedTreatments && post.relatedTreatments.length > 0) {
+    return unique(post.relatedTreatments)
+  }
+
+  return DEFAULT_RELATED_TREATMENTS_BY_POST_SLUG[post.slug] || []
+}
+
+export function getResolvedRelatedPostSlugs(
+  post: Pick<BlogPost, 'slug' | 'relatedPosts' | 'relatedTreatments'>,
+  allPosts: BlogPost[],
+  limit = 2
+): string[] {
+  if (post.relatedPosts && post.relatedPosts.length > 0) {
+    return unique(post.relatedPosts.filter((slug) => slug !== post.slug)).slice(0, limit)
+  }
+
+  const defaultRelatedPosts = DEFAULT_RELATED_POSTS_BY_POST_SLUG[post.slug]
+  if (defaultRelatedPosts && defaultRelatedPosts.length > 0) {
+    return unique(defaultRelatedPosts.filter((slug) => slug !== post.slug)).slice(0, limit)
+  }
+
+  const relatedTreatmentSlugs = getResolvedRelatedTreatmentSlugs(post)
+
+  if (relatedTreatmentSlugs.length === 0) {
+    return []
+  }
+
+  return allPosts
+    .filter((candidate) => candidate.slug !== post.slug)
+    .filter((candidate) => {
+      const candidateTreatmentSlugs = getResolvedRelatedTreatmentSlugs(candidate)
+      return candidateTreatmentSlugs.some((slug) => relatedTreatmentSlugs.includes(slug))
+    })
+    .map((candidate) => candidate.slug)
+    .slice(0, limit)
+}
+
+export function getRelatedPostsForTreatment(
+  treatmentSlug: TreatmentSlug,
+  allPosts: BlogPost[],
+  limit = 4
+): BlogPost[] {
+  return allPosts
+    .filter((post) => getResolvedRelatedTreatmentSlugs(post).includes(treatmentSlug))
+    .sort((left, right) => {
+      const leftFeatured = left.featured ? 1 : 0
+      const rightFeatured = right.featured ? 1 : 0
+
+      if (leftFeatured !== rightFeatured) {
+        return rightFeatured - leftFeatured
+      }
+
+      return right.publishDate.localeCompare(left.publishDate)
+    })
+    .slice(0, limit)
+}


### PR DESCRIPTION
## What changed

### New UI components
- `src/lib/content-relationships.ts` — slug resolver: given a post's `relatedTreatments`/`relatedPosts` frontmatter, returns fully-resolved objects for rendering
- `src/components/ui/RelatedTreatmentsSection.tsx` — renders treatment cards at bottom of blog posts
- `src/components/ui/RelatedPostsSection.tsx` — renders post cards at bottom of blog posts
- `src/components/ui/RelatedBlogCard.tsx` — rewritten to show a 2-column grid of linked posts (replaces single-post card)
- `src/app/blog/[slug]/page.tsx` — integrates both new sections after post content

### Blog post frontmatter (4 existing posts)
Adds `relatedTreatments` and `relatedPosts` arrays plus inline cross-link paragraphs in the body:
- `doencas-inflamatorias-intestinais-acompanhamento.md`
- `fissura-anal-toxina-botulinica-tratamento.md`
- `hpv-anal-condilomas-riscos-tratamento-rastreio.md`
- `tratamento-fistulas-anorretais.md`

### New blog posts (5)
- `cisto-pilonidal-cisto-sacrococcigeo-mesma-coisa`
- `ligadura-elastica-hemorroidas-doi-recuperacao`
- `thd-hemorroidas-quando-indicado`
- `proctologista-e-coloproctologista-qual-diferenca-quando-procurar-atendimento`
- `primeira-consulta-proctologista-curitiba-o-que-esperar`

## Why

Internal linking between blog posts and treatment pages improves crawl depth and reduces bounce. The new posts target "proctologista curitiba" and procedural intent keywords not yet covered.

## Dependencies

**None.** Fully independent — can be merged before or after any other PR in this series.

## Conflict note

The 4 modified existing posts also appear in PR D (proctologista keywords). Each file has distinct changes (PR D: frontmatter SEO only; PR E: relatedTreatments/relatedPosts + inline body links). Merge one first and resolve the 4-file conflict manually on the second.

## Validation

- `bun run build` passes
- Related sections render at bottom of blog posts

---

> Part of the split from analuizamrocha/web#40